### PR TITLE
Add Function To Get Fin Message From SWIFT MT Records

### DIFF
--- a/swiftmt/101_request_for_transfer.bal
+++ b/swiftmt/101_request_for_transfer.bal
@@ -60,15 +60,25 @@ public type MT101Message record {|
 # + MT59 -  Beneficiary Customer 
 # + MT59A - Beneficiary Customer (Option A)
 public type MT101Transaction record {|
-    MT50C MT50C?;
-    MT50L MT50L?;
     MT21 MT21;
     MT21F MT21F?;
+    MT23E[] MT23E?;
     MT32B MT32B;
+    MT50C MT50C?;
+    MT50L MT50L?;
     MT50F MT50F?;
     MT50G MT50G?;
     MT50H MT50H?;
+    MT52A MT52A?;
+    MT52C MT52C?;
+    MT56A MT56A?;
+    MT56C MT56C?;
+    MT56D MT56D?;
+    MT57A MT57A?;
     MT57C MT57C?;
+    MT57D MT57D?;
+    MT59 MT59?;
+    MT59A MT59A?;
     MT59F MT59F?;
     MT70 MT70?;
     MT77B MT77B?;
@@ -76,16 +86,6 @@ public type MT101Transaction record {|
     MT71A MT71A;
     MT25A MT25A?;
     MT36 MT36?;
-    MT23E[] MT23E?;
-    MT52A MT52A?;
-    MT56A MT56A?;
-    MT56C MT56C?;
-    MT56D MT56D?;
-    MT57A MT57A?;
-    MT57D MT57D?;
-    MT52C MT52C?;
-    MT59 MT59?;
-    MT59A MT59A?;
 |};
 
 # Defines the elements of the MT101 message block 4.
@@ -108,15 +108,15 @@ public type MT101Block4 record {|
     MT20 MT20;
     MT21R MT21R?;
     MT28D MT28D;
-    MT30 MT30;
-    MT25 MT25?;
     MT50C MT50C?;
     MT50L MT50L?;
     MT50F MT50F?;
     MT50G MT50G?;
     MT50H MT50H?;
-    MT51A MT51A?;
     MT52A MT52A?;
     MT52C MT52C?;
+    MT51A MT51A?;
+    MT30 MT30;
+    MT25 MT25?;
     MT101Transaction[] Transaction;
 |};

--- a/swiftmt/102_multiple_customer_credit_transfer.bal
+++ b/swiftmt/102_multiple_customer_credit_transfer.bal
@@ -39,28 +39,28 @@
 # + MT77B - Regulatory Reporting
 # + Transaction - An array of transactions containing the detailed payment instructions
 public type MT102Block4 record {|
-    MT19 MT19?;
     MT20 MT20;
-    MT13C MT13C?;
     MT23 MT23;
-    MT26T MT26T?;
-    MT32A MT32A;
-    MT36 MT36?;
+    MT51A MT51A?;
     MT50A MT50A?;
     MT50F MT50F?;
     MT50K MT50K?;
-    MT51A MT51A?;
     MT52A MT52A?;
     MT52C MT52C?;
+    MT26T MT26T?;
+    MT77B MT77B?;
+    MT71A MT71A?;
+    MT36 MT36?;
+    MT102Transaction[] Transaction;
+    MT32A MT32A;
+    MT19 MT19?;
+    MT71G MT71G?;
+    MT13C MT13C?;
     MT53A MT53A?;
     MT53C MT53C?;
     MT54A MT54A?;
     MT52B MT52B?;
-    MT71A MT71A?;
-    MT71G MT71G?;
     MT72 MT72?;
-    MT77B MT77B?;
-    MT102Transaction[] Transaction;
 |};
 
 # Defines the transaction-related elements of an MT102 transaction.
@@ -88,10 +88,7 @@ public type MT102Block4 record {|
 # + MT77B - Regulatory Reporting
 public type MT102Transaction record {|
     MT21 MT21;
-    MT26T MT26T?;
-    MT33B MT33B?;
     MT32B MT32B;
-    MT36 MT36?;
     MT50A MT50A?;
     MT50F MT50F?;
     MT50K MT50K?;
@@ -104,10 +101,13 @@ public type MT102Transaction record {|
     MT59A MT59A?;
     MT59F MT59F?;
     MT70 MT70?;
+    MT26T MT26T?;
+    MT77B MT77B?;
+    MT33B MT33B?;
     MT71A MT71A?;
     MT71F MT71F?;
     MT71G MT71G?;
-    MT77B MT77B?;
+    MT36 MT36?;
 |};
 
 # Defines the structure of an MT102 message.

--- a/swiftmt/102_stp_multiple_customer_credit_transfer.bal
+++ b/swiftmt/102_stp_multiple_customer_credit_transfer.bal
@@ -37,31 +37,30 @@
 # + MT77B - Regulatory Reporting
 # + Transaction - An array of transactions containing the detailed payment instructions
 public type MT102STPBlock4 record {|
-    MT19 MT19?;
     MT20 MT20;
-    MT13C MT13C?;
     MT23 MT23;
-    MT26T MT26T?;
-    MT32A MT32A;
-    MT36 MT36?;
     MT50A MT50A?;
     MT50F MT50F?;
     MT50K MT50K?;
     MT52A MT52A?;
+    MT26T MT26T?;
+    MT77B MT77B?;
+    MT71A MT71A?;
+    MT36 MT36?;
+    MT102STPTransaction[] Transaction;
+    MT32A MT32A;
+    MT19 MT19?;
+    MT71G MT71G?;
+    MT13C MT13C?;
     MT53A MT53A?;
     MT53C MT53C?;
     MT54A MT54A?;
     MT52B MT52B?;
-    MT71A MT71A?;
-    MT71G MT71G?;
     MT72 MT72?;
-    MT77B MT77B?;
-    MT102STPTransaction[] Transaction;
 |};
 
 # Defines the transaction-related elements of an MT102 STP transaction.
 #
-# + MT13C - Time Indication
 # + MT21 - Transaction Reference
 # + MT26T - Transaction Type Code
 # + MT33B - Currency/Instructed Amount
@@ -81,12 +80,8 @@ public type MT102STPBlock4 record {|
 # + MT71G - Receiver's Charges Information (Option G)
 # + MT77B - Regulatory Reporting
 public type MT102STPTransaction record {|
-    MT13C MT13C?;
     MT21 MT21;
-    MT26T MT26T?;
-    MT33B MT33B?;
     MT32B MT32B;
-    MT36 MT36?;
     MT50A MT50A?;
     MT50F MT50F?;
     MT50K MT50K?;
@@ -96,10 +91,13 @@ public type MT102STPTransaction record {|
     MT59A MT59A?;
     MT59F MT59F?;
     MT70 MT70?;
+    MT26T MT26T?;
+    MT77B MT77B?;
+    MT33B MT33B?;
     MT71A MT71A?;
     MT71F MT71F?;
     MT71G MT71G?;
-    MT77B MT77B?;
+    MT36 MT36?;
 |};
 
 # Defines the structure of an MT102 STP message.

--- a/swiftmt/103_remit_single_customer_credit_transfer.bal
+++ b/swiftmt/103_remit_single_customer_credit_transfer.bal
@@ -51,7 +51,6 @@ import ballerina/data.xmldata;
 # + MT59 - Beneficiary Customer
 # + MT59A - Beneficiary Customer (Option A)
 # + MT59F - Beneficiary Customer (Option F)
-# + MT70 - Remittance Information
 # + MT71A - Details of Charges
 # + MT71F - Sender's Charges Information (Option F)
 # + MT71G - Receiver's Charges Information (Option G)
@@ -92,7 +91,6 @@ public type MT103REMITBlock4 record {|
     MT59 MT59?;
     MT59A MT59A?;
     MT59F MT59F?;
-    MT70 MT70?;
     MT71A MT71A;
     MT71F MT71F?;
     MT71G MT71G?;

--- a/swiftmt/104_direct_debit_transfer.bal
+++ b/swiftmt/104_direct_debit_transfer.bal
@@ -41,30 +41,30 @@
 # + MT77B - Regulatory Reporting
 # + Transaction - An array of transactions containing the detailed payment instructions
 public type MT104Block4 record {|
-    MT19 MT19?;
     MT20 MT20;
-    MT21E MT21E?;
     MT21R MT21R?;
     MT23E MT23E?;
-    MT26T MT26T?;
+    MT21E MT21E?;
     MT30 MT30;
-    MT32B MT32B;
-    MT50A MT50A?;
+    MT51A MT51A?;
     MT50C MT50C?;
     MT50L MT50L?;
+    MT50A MT50A?;
     MT50K MT50K?;
-    MT51A MT51A?;
     MT52A MT52A?;
     MT52C MT52C?;
     MT52D MT52D?;
-    MT53A MT53A?;
-    MT53B MT53B?;
+    MT26T MT26T?;
+    MT77B MT77B?;
     MT71A MT71A?;
+    MT72 MT72?;
+    MT104Transaction[] Transaction;
+    MT32B MT32B;
+    MT19 MT19?;
     MT71F MT71F?;
     MT71G MT71G?;
-    MT72 MT72?;
-    MT77B MT77B?;
-    MT104Transaction[] Transaction;
+    MT53A MT53A?;
+    MT53B MT53B?;
 |};
 
 # Defines the transaction-related elements of an MT104 message.
@@ -82,12 +82,9 @@ public type MT104Block4 record {|
 # + MT50C - Instructing Party (Option C)
 # + MT50L - Instructing Party (Option L)
 # + MT50K - Creditor (Option K)
-# + MT51A - Sending Institution
 # + MT52A - Creditor's Bank (Option A)
 # + MT52C - Creditor's Bank (Option C)
 # + MT52D - Creditor's Bank (Option D)
-# + MT53A - Sendor's Correspondant (Option A)
-# + MT53B - Sendor's Correspondant (Option B)
 # + MT57A - Debtor's Bank (Option A)
 # + MT57C - Debtor's Bank (Option C)
 # + MT57D - Debtor's Bank (Option D)
@@ -97,39 +94,34 @@ public type MT104Block4 record {|
 # + MT71A - Details of Charges
 # + MT71F - Sender's Charges Information (Option F)
 # + MT71G - Receiver's Charges Information (Option G)
-# + MT72 - Sender to Receiver Information
 # + MT77B - Regulatory Reporting
 public type MT104Transaction record {|
     MT21 MT21;
-    MT26T MT26T?;
+    MT23E MT23E?;
     MT21C MT21C?;
     MT21D MT21D?;
     MT21E MT21E?;
-    MT23E MT23E?;
     MT32B MT32B;
-    MT33B MT33B?;
-    MT36 MT36?;
-    MT50A MT50A?;
     MT50C MT50C?;
     MT50L MT50L?;
+    MT50A MT50A?;
     MT50K MT50K?;
-    MT51A MT51A?;
     MT52A MT52A?;
     MT52C MT52C?;
     MT52D MT52D?;
-    MT53A MT53A?;
-    MT53B MT53B?;
     MT57A MT57A?;
     MT57C MT57C?;
     MT57D MT57D?;
     MT59 MT59?;
     MT59A MT59A?;
     MT70 MT70?;
+    MT26T MT26T?;
+    MT77B MT77B?;
+    MT33B MT33B?;
     MT71A MT71A?;
     MT71F MT71F?;
     MT71G MT71G?;
-    MT72 MT72?;
-    MT77B MT77B?;
+    MT36 MT36?;
 |};
 
 # Defines the structure of an MT104 message.

--- a/swiftmt/105_edifact_envelope.bal
+++ b/swiftmt/105_edifact_envelope.bal
@@ -24,10 +24,10 @@ import ballerina/data.xmldata;
 # + MT27 - Sequence of Total
 # + MT77F - EDIFACT Message
 public type MT105Block4 record {|
-    MT12 MT12;
+    MT27 MT27;
     MT20 MT20;
     MT21 MT21;
-    MT27 MT27;
+    MT12 MT12;
     MT77F MT77F;
 |};
 

--- a/swiftmt/107_general_direct_debit.bal
+++ b/swiftmt/107_general_direct_debit.bal
@@ -40,29 +40,29 @@
 # + MT77B - Regulatory Reporting
 # + Transaction - An array of transactions containing the detailed payment instructions
 public type MT107Block4 record {|
-    MT19 MT19?;
     MT20 MT20;
-    MT21E MT21E?;
     MT23E MT23E?;
-    MT26T MT26T?;
+    MT21E MT21E?;
     MT30 MT30;
-    MT32B MT32B;
-    MT50A MT50A?;
+    MT51A MT51A?;
     MT50C MT50C?;
     MT50L MT50L?;
+    MT50A MT50A?;
     MT50K MT50K?;
-    MT51A MT51A?;
     MT52A MT52A?;
     MT52C MT52C?;
     MT52D MT52D?;
-    MT53A MT53A?;
-    MT53B MT53B?;
+    MT26T MT26T?;
+    MT77B MT77B?;
     MT71A MT71A?;
+    MT72 MT72?;
+    MT107Transaction[] Transaction;
+    MT32B MT32B;
+    MT19 MT19?;
     MT71F MT71F?;
     MT71G MT71G?;
-    MT72 MT72?;
-    MT77B MT77B?;
-    MT107Transaction[] Transaction;
+    MT53A MT53A?;
+    MT53B MT53B?;
 |};
 
 # Defines the transaction-related elements of an MT104 message.
@@ -72,6 +72,7 @@ public type MT107Block4 record {|
 # + MT21D - Regulatory Information
 # + MT21E - Instruction Code
 # + MT23E - Instruction Code (Array)
+# + MT26T - Transaction Type Code
 # + MT32B - Currency/Transaction Amount
 # + MT33B - Currency/Instructed Amount
 # + MT36 - Exchange Rate
@@ -79,12 +80,9 @@ public type MT107Block4 record {|
 # + MT50C - Instructing Party (Option C)
 # + MT50L - Instructing Party (Option L)
 # + MT50K - Creditor (Option K)
-# + MT51A - Sending Institution
 # + MT52A - Creditor's Bank (Option A)
 # + MT52C - Creditor's Bank (Option C)
 # + MT52D - Creditor's Bank (Option D)
-# + MT53A - Sendor's Correspondant (Option A)
-# + MT53B - Sendor's Correspondant (Option B)
 # + MT57A - Debtor's Bank (Option A)
 # + MT57C - Debtor's Bank (Option C)
 # + MT57D - Debtor's Bank (Option D)
@@ -94,38 +92,34 @@ public type MT107Block4 record {|
 # + MT71A - Details of Charges
 # + MT71F - Sender's Charges Information (Option F)
 # + MT71G - Receiver's Charges Information (Option G)
-# + MT72 - Sender to Receiver Information
 # + MT77B - Regulatory Reporting
 public type MT107Transaction record {|
     MT21 MT21;
+    MT23E MT23E?;
     MT21C MT21C?;
     MT21D MT21D?;
     MT21E MT21E?;
-    MT23E MT23E?;
     MT32B MT32B;
-    MT33B MT33B?;
-    MT36 MT36?;
-    MT50A MT50A?;
     MT50C MT50C?;
     MT50L MT50L?;
+    MT50A MT50A?;
     MT50K MT50K?;
-    MT51A MT51A?;
     MT52A MT52A?;
     MT52C MT52C?;
     MT52D MT52D?;
-    MT53A MT53A?;
-    MT53B MT53B?;
     MT57A MT57A?;
     MT57C MT57C?;
     MT57D MT57D?;
     MT59 MT59?;
     MT59A MT59A?;
     MT70 MT70?;
+    MT26T MT26T?;
+    MT77B MT77B?;
+    MT33B MT33B?;
     MT71A MT71A?;
     MT71F MT71F?;
     MT71G MT71G?;
-    MT72 MT72?;
-    MT77B MT77B?;
+    MT36 MT36?;
 |};
 
 # Defines the structure of an MT107 message.

--- a/swiftmt/110_advice_of_cheque(s).bal
+++ b/swiftmt/110_advice_of_cheque(s).bal
@@ -38,6 +38,13 @@
 # + MT72 - Sender to Receiver Information
 public type MT110Block4 record {|
     MT20 MT20;
+    MT53A MT53A?;
+    MT53B MT53B?;
+    MT53D MT53D?;
+    MT54A MT54A?;
+    MT54B MT54B?;
+    MT54D MT54D?;
+    MT72 MT72?;
     MT21 MT21;
     MT30 MT30;
     MT32A MT32A?;
@@ -48,15 +55,8 @@ public type MT110Block4 record {|
     MT52A MT52A?;
     MT52B MT52B?;
     MT52D MT52D?;
-    MT53A MT53A?;
-    MT53B MT53B?;
-    MT53D MT53D?;
-    MT54A MT54A?;
-    MT54B MT54B?;
-    MT54D MT54D?;
     MT59 MT59?;
     MT59F MT59F?;
-    MT72 MT72?;
 |};
 
 # Defines the structure of an MT110 message.

--- a/swiftmt/111_request_to_stop_cheque_payment.bal
+++ b/swiftmt/111_request_to_stop_cheque_payment.bal
@@ -24,8 +24,7 @@
 # + MT52A - Drawer Bank (Option A)  
 # + MT52B - Drawer Bank (Option B)  
 # + MT52D - Drawer Bank (Option D)    
-# + MT59 - Payee  
-# + MT59F - Payee (Option F)  
+# + MT59 - Payee    
 # + MT75 - Queries
 public type MT111Block4 record {|
     MT20 MT20;
@@ -37,7 +36,6 @@ public type MT111Block4 record {|
     MT52B MT52B?;
     MT52D MT52D?;
     MT59 MT59?;
-    MT59F MT59F?;
     MT75 MT75?;
 |};
 

--- a/swiftmt/112_status_of_stop_cheque_payment_request.bal
+++ b/swiftmt/112_status_of_stop_cheque_payment_request.bal
@@ -24,8 +24,7 @@
 # + MT52A - Drawer Bank (Option A)  
 # + MT52B - Drawer Bank (Option B)  
 # + MT52D - Drawer Bank (Option D)    
-# + MT59 - Payee  
-# + MT59F - Payee (Option F)  
+# + MT59 - Payee    
 # + MT76 - Answers
 public type MT112Block4 record {|
     MT20 MT20;
@@ -37,7 +36,6 @@ public type MT112Block4 record {|
     MT52B MT52B?;
     MT52D MT52D?;
     MT59 MT59?;
-    MT59F MT59F?;
     MT76 MT76;
 |};
 

--- a/swiftmt/204_financial_markets_direct_debit.bal
+++ b/swiftmt/204_financial_markets_direct_debit.bal
@@ -27,8 +27,8 @@
 # + MT72 - Sender to Receiver Information
 # + Transaction - Array of MT204 transactions containing detailed payment instructions
 public type MT204Block4 record {|
-    MT19 MT19;
     MT20 MT20;
+    MT19 MT19;
     MT30 MT30;
     MT57A MT57A?;
     MT57B MT57B?;

--- a/swiftmt/205_financial_institution_transfer_execution.bal
+++ b/swiftmt/205_financial_institution_transfer_execution.bal
@@ -32,10 +32,6 @@
 # + MT57D - Account With Institution (Option D)
 # + MT58A - Beneficiary Institution (Option A)
 # + MT58D - Beneficiary Institution (Option D)
-# + MT59 - Beneficiary Customer 
-# + MT59A - Beneficiary Customer (Option A)
-# + MT59F - Beneficiary Customer (Option F)
-# + MT70 - Remittance Information
 # + MT72 - Sender to Receiver Information
 public type MT205Block4 record {|
     MT20 MT20;
@@ -54,10 +50,6 @@ public type MT205Block4 record {|
     MT57D MT57D?;
     MT58A MT58A?;
     MT58D MT58D?;
-    MT59 MT59?;
-    MT59A MT59A?;
-    MT59F MT59F?;
-    MT70 MT70?;
     MT72 MT72?;
 |};
 

--- a/swiftmt/205_financial_institution_transfer_execution.bal
+++ b/swiftmt/205_financial_institution_transfer_execution.bal
@@ -20,7 +20,6 @@
 # + MT21 - Related Reference
 # + MT13C - Time Indication
 # + MT32A - Value Date, Currency Code, and Amount
-# + MT33B - Currency/Instructed Amount
 # + MT52A - Ordering Institution (Option A)
 # + MT52D - Ordering Institution (Option D)
 # + MT53A - Sender’s Correspondent (Option A)
@@ -43,7 +42,6 @@ public type MT205Block4 record {|
     MT21 MT21;
     MT13C MT13C?;
     MT32A MT32A;
-    MT33B MT33B?;
     MT52A MT52A?;
     MT52D MT52D?;
     MT53A MT53A?;

--- a/swiftmt/210_notice_to_receive.bal
+++ b/swiftmt/210_notice_to_receive.bal
@@ -31,7 +31,7 @@
 public type MT210Block4 record {|
     MT20 MT20;
     MT25A MT25?;
-    MT30 MT30?;
+    MT30 MT30;
     MT21 MT21;
     MT32B MT32B;
     MT50 MT50?;

--- a/swiftmt/210_notice_to_receive.bal
+++ b/swiftmt/210_notice_to_receive.bal
@@ -30,9 +30,9 @@
 # + MT56D - Intermediary (Option D)
 public type MT210Block4 record {|
     MT20 MT20;
-    MT21 MT21;
     MT25A MT25?;
     MT30 MT30?;
+    MT21 MT21;
     MT32B MT32B;
     MT50 MT50?;
     MT50C MT50C?;

--- a/swiftmt/920_request_message.bal
+++ b/swiftmt/920_request_message.bal
@@ -24,7 +24,7 @@ public type MT920Block4 record {|
     MT20 MT20;
     MT12 MT12;
     MT25A MT25;
-    MT34F[] MT34F;
+    MT34F[] MT34F?;
 |};
 
 # Defines the structure of an MT920 message.

--- a/swiftmt/940_customer_statement.bal
+++ b/swiftmt/940_customer_statement.bal
@@ -31,18 +31,18 @@
 # + MT62M - Intermediate Closing Balance
 public type MT940Block4 record {|
     MT20 MT20;
+    MT21 MT21?;
     MT25A MT25?;
     MT25P MT25P?;
-    MT21 MT21?;
     MT28C MT28C;
     MT60F MT60F;
+    MT60M[] MT60M?;
     MT61[] MT61?;
     MT86[] MT86?;
     MT62F MT62F;
+    MT62M[] MT62M?;
     MT64[] MT64?;
     MT65[] MT65?;
-    MT60M[] MT60M?;
-    MT62M[] MT62M?;
 |};
 
 # Defines the structure of an MT940 message.

--- a/swiftmt/941_balance_report.bal
+++ b/swiftmt/941_balance_report.bal
@@ -30,19 +30,19 @@
 # + MT90C - Number and Sum of Credit Entries
 # + MT90D - Number and Sum of Debit Entries
 public type MT941Block4 record {|
-    MT13D MT13D?;
     MT20 MT20;
     MT21 MT21?;
     MT25A MT25?;
     MT25P MT25P?;
     MT28 MT28;
+    MT13D MT13D?;
     MT60F MT60F?;
+    MT90D MT90D?;
+    MT90C MT90C?;
     MT62F MT62F?;
     MT64[] MT64?;
     MT65[] MT65?;
     MT86[] MT86?;
-    MT90C MT90C?;
-    MT90D MT90D?;
 |};
 
 # Defines the structure of an MT941 message.

--- a/swiftmt/941_balance_report.bal
+++ b/swiftmt/941_balance_report.bal
@@ -39,7 +39,7 @@ public type MT941Block4 record {|
     MT60F MT60F?;
     MT90D MT90D?;
     MT90C MT90C?;
-    MT62F MT62F?;
+    MT62F MT62F;
     MT64[] MT64?;
     MT65[] MT65?;
     MT86[] MT86?;

--- a/swiftmt/942_interim_transaction_report.bal
+++ b/swiftmt/942_interim_transaction_report.bal
@@ -28,17 +28,17 @@
 # + MT90C - Number and Sum of Credit Entries
 # + MT90D - Number and Sum of Debit Entries
 public type MT942Block4 record {|
-    MT13D MT13D;
     MT20 MT20;
     MT21 MT21?;
     MT25A MT25?;
     MT25P MT25P?;
     MT28C MT28C;
     MT34F[] MT34F;
+    MT13D MT13D;
     MT61[] MT61?;
     MT86[] MT86?;
-    MT90C MT90C?;
     MT90D MT90D?;
+    MT90C MT90C?;
 |};
 
 # Defines the structure of an MT942 message.

--- a/swiftmt/950_statement_message.bal
+++ b/swiftmt/950_statement_message.bal
@@ -29,10 +29,10 @@ public type MT950Block4 record {|
     MT20 MT20;
     MT25A MT25;
     MT28C MT28C;
-    MT60F MT60F?;
+    MT60F MT60F;
     MT60M[] MT60M?;
     MT61[] MT61?;
-    MT62F MT62F?;
+    MT62F MT62F;
     MT62M[] MT62M?;
     MT64[] MT64?;
 |};

--- a/swiftmt/970_netting_statement.bal
+++ b/swiftmt/970_netting_statement.bal
@@ -29,10 +29,10 @@ public type MT970Block4 record {|
     MT20 MT20;
     MT25A MT25;
     MT28C MT28C;
-    MT60F MT60F?;
+    MT60F MT60F;
     MT60M[] MT60M?;
     MT61[] MT61?;
-    MT62F MT62F?;
+    MT62F MT62F;
     MT62M[] MT62M?;
     MT64[] MT64?;
 |};

--- a/swiftmt/972_netting_interim_statement.bal
+++ b/swiftmt/972_netting_interim_statement.bal
@@ -29,10 +29,10 @@ public type MT972Block4 record {|
     MT20 MT20;
     MT25A MT25;
     MT28C MT28C;
-    MT60F MT60F?;
+    MT60F MT60F;
     MT60M[] MT60M?;
     MT61[] MT61?;
-    MT62F MT62F?;
+    MT62F MT62F;
     MT62M[] MT62M?;
     MT64[] MT64?;
 |};

--- a/swiftmt/Dependencies.toml
+++ b/swiftmt/Dependencies.toml
@@ -61,4 +61,3 @@ modules = [
 	{org = "ballerinax", packageName = "financial.swift.mt", moduleName = "financial.swift.mt.com.prowidesoftware.swift.model"},
 	{org = "ballerinax", packageName = "financial.swift.mt", moduleName = "financial.swift.mt.java.lang"}
 ]
-

--- a/swiftmt/common_records.bal
+++ b/swiftmt/common_records.bal
@@ -112,8 +112,8 @@ public type MT20 record {|
 # + AdrsLine - The address of the ordering customer
 public type MT50 record {|
     string name?;
-    Nm[] Nm?;
-    AdrsLine[] AdrsLine?;
+    Nm[] Nm;
+    AdrsLine[] AdrsLine;
 |};
 
 # Defines the reference.
@@ -500,7 +500,7 @@ public type CntyNTw record {|
 public type MT50F record {|
     string name?;
     PrtyIdn PrtyIdn;
-    CdTyp[] CdTyp;
+    CdTyp[] CdTyp?;
     Nm[] Nm?;
     AdrsLine[] AdrsLine?;
     CntyNTw[] CntyNTw?;

--- a/swiftmt/common_records.bal
+++ b/swiftmt/common_records.bal
@@ -22,7 +22,7 @@ import ballerina/data.xmldata;
 # + value - The value of end to end reference
 public type NdToNdTxRef record {|
     string name?;
-    string value;
+    string value?;
 |};
 
 # Defines the validation flag.
@@ -1521,7 +1521,7 @@ public type MT54B record {|
     string name?;
     PrtyIdnTyp PrtyIdnTyp?;
     PrtyIdn PrtyIdn?;
-    Lctn Lctn;
+    Lctn Lctn?;
 |};
 
 # Defines the MT54D field in block 4.
@@ -1576,7 +1576,6 @@ public type MT21D record {|
 # + MT70 - Remmitance Information  
 # + MT72 - Sender to Receiver Information
 public type UndrlygCstmrCdtTrf record {|
-    MT33B MT33B?;
     MT50A MT50A?;
     MT50F MT50F?;
     MT50K MT50K?;
@@ -1592,6 +1591,7 @@ public type UndrlygCstmrCdtTrf record {|
     MT59F MT59F?;
     MT70 MT70?;
     MT72 MT72?;
+    MT33B MT33B?;
 |};
 
 # Defines the elements of the copy of original message.

--- a/swiftmt/modules/com.prowidesoftware.swift.io/ConversionService.bal
+++ b/swiftmt/modules/com.prowidesoftware.swift.io/ConversionService.bal
@@ -64,7 +64,7 @@ public distinct class ConversionService {
     #
     # + arg0 - The `string` value required to map with the Java method parameter.
     # + return - The `string` value returning from the Java mapping.
-    public function getFIN(string arg0) returns string {
+    public isolated function getFIN(string arg0) returns string {
         return java:toString(com_prowidesoftware_swift_io_ConversionService_getFIN(self.jObj, java:fromString(arg0))) ?: "";
     }
 
@@ -206,7 +206,7 @@ function com_prowidesoftware_swift_io_ConversionService_getClass(handle receiver
     paramTypes: []
 } external;
 
-function com_prowidesoftware_swift_io_ConversionService_getFIN(handle receiver, handle arg0) returns handle = @java:Method {
+isolated function com_prowidesoftware_swift_io_ConversionService_getFIN(handle receiver, handle arg0) returns handle = @java:Method {
     name: "getFIN",
     'class: "com.prowidesoftware.swift.io.ConversionService",
     paramTypes: ["java.lang.String"]

--- a/swiftmt/n95_queries.bal
+++ b/swiftmt/n95_queries.bal
@@ -27,10 +27,10 @@
 public type MTn95Block4 record {|
     MT20 MT20;
     MT21 MT21;
-    MT11R MT11R?;
-    MT11S MT11S?;
     MT75 MT75;
     MT77A MT77A?;
+    MT11R MT11R?;
+    MT11S MT11S?;
     MT79 MT79?;
     MessageCopy MessageCopy?;
 |};

--- a/swiftmt/n96_answers.bal
+++ b/swiftmt/n96_answers.bal
@@ -27,10 +27,10 @@
 public type MTn96Block4 record {|
     MT20 MT20;
     MT21 MT21;
-    MT11R MT11R?;
-    MT11S MT11S?;
     MT76 MT76;
     MT77A MT77A?;
+    MT11R MT11R?;
+    MT11S MT11S?;
     MT79 MT79?;
     MessageCopy MessageCopy?;
 |};


### PR DESCRIPTION
## Purpose
Introduce a new function that retrieves a FIN message from SWIFT MT records. This function facilitates the conversion of structured SWIFT MT records into their equivalent FIN message representation, ensuring compatibility with systems that rely on traditional SWIFT FIN messages

## Goals
Enhance the functionality of the SWIFT MT library by providing seamless extraction and transformation capabilities. This addition aims to improve usability, streamline message processing workflows, and ensure that users can generate FIN messages directly from structured SWIFT MT data.