### PR TITLE
Add Ballerina Records for SWIFT `MT300` - `MT341` Messages  

### DIFF
--- a/swiftmt/300_foreign_exchange_confirmation.bal
+++ b/swiftmt/300_foreign_exchange_confirmation.bal
@@ -1,0 +1,297 @@
+// Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# Defines the structure of an MT300 message.
+#
+# + block1 - Basic Header Block 
+# + block2 - Application Header Block
+# + block3 - User Header Block 
+# + block4 - Text Block containing Foreign Exchange Confirmation details 
+# + block5 - Trailer Block 
+# + UnparsedTexts - Any additional unparsed texts
+public type MT300Message record {|
+    Block1 block1?;
+    Block2 block2;
+    Block3 block3?;
+    MT300Block4 block4;
+    Block5 block5?;
+    UnparsedTexts UnparsedTexts?;
+|};
+
+# Defines the elements of the MT300 message block 4.
+#
+# + MT15A - New Sequence  
+# + MT20 - Sender's Reference  
+# + MT21 - Related Reference  
+# + MT22A - Type of Operation  
+# + MT94A - Scope of Operation  
+# + MT22C - Common Reference  
+# + MT17T - Block Trade Indicator  
+# + MT17U - Split Settlement Indicator  
+# + MT17I - Payment versus Payment Indicator  
+# + MT82A - Party A  
+# + MT87A - Party B  
+# + MT83A - Fund or Beneficiary Customer  
+# + MT77H - Type, Date, Version of Agreement  
+# + MT77D - Terms of Agreement  
+# + MT14C - Year of Definitions  
+# + MT17F - Non-Deliverable Indicator  
+# + MT17O - NDF Open Indicator  
+# + MT32E - Settlement Currency  
+# + MT30U - Valuation Date  
+# + MT14S - Settlement Rate Source  
+# + MT26K - Calculation Agent  
+# + MT21A - Reference to Opening Confirmation  
+# + MT14E - Clearing or Settlement Session  
+# + Transaction - Transaction details  
+# + OptionalGeneralInformation - Optional General Information  
+# + SplitSettlementDetails - Split Settlement Details  
+# + ReportingInformation - Reporting Information  
+# + PostTradeEvents - Post Trade Events
+public type MT300Block4 record {|
+    MT15A MT15A;
+    MT20 MT20;
+    MT21 MT21?;
+    MT22A MT22A;
+    MT94A MT94A?;
+    MT22C MT22C;
+    MT17T MT17T?;
+    MT17U MT17U?;
+    MT17I MT17I?;
+    MT82A MT82A;
+    MT87A MT87A;
+    MT83A MT83A?;
+    MT77H MT77H?;
+    MT77D MT77D?;
+    MT14C MT14C?;
+    MT17F MT17F?;
+    MT17O MT17O?;
+    MT32E MT32E?;
+    MT30U MT30U?;
+    MT14S MT14S?;
+    MT26K MT26K?;
+    MT21A MT21A?;
+    MT14E MT14E?;
+    MT300Transaction Transaction;
+    MT300OptionalGeneralInformation OptionalGeneralInformation?;
+    MT300SplitSettlementDetails SplitSettlementDetails?;
+    MT300ReportingInformation ReportingInformation?;
+    MT300PostTradeEvents PostTradeEvents?;
+|};
+
+# Define the transacions in the MT300 message.
+#
+# + MT15B - New Sequence  
+# + MT30T - Trade Date  
+# + MT30V - Value Date  
+# + MT36 - Exchange Rate  
+# + MT39M - Payment Clearing Centre  
+# + MT35C - Digutal Token Identifier  
+# + AmountBought - Amount bought details  
+# + AmountSold - Amount sold details
+public type MT300Transaction record {|
+    MT15B MT15B;
+    MT30T MT30T;
+    MT30V MT30V;
+    MT36 MT36;
+    MT39M MT39M?;
+    MT35C MT35C?;
+    MT300AmountBought AmountBought;
+    MT300AmountSold AmountSold;
+|};
+
+# Define the amount bought details in the MT300Transaction element.
+#
+# + MT32B - Currency, Amount  
+# + MT53A - Delivery Agent  
+# + MT56A - Intermediary  
+# + MT57A - Receiving Agent
+public type MT300AmountBought record {|
+    MT32B MT32B;
+    MT53A MT53A?;
+    MT56A MT56A?;
+    MT57A MT57A;
+|};
+
+# Define the amount sold details in the MT300Transaction element.
+#
+# + MT33B - Currency, Amount  
+# + MT53A - Delivery Agent  
+# + MT56A - Intermediary  
+# + MT57A - Receiving Agent  
+# + MT58A - Beneficiary Institution
+public type MT300AmountSold record {|
+    MT33B MT33B;
+    MT53A MT53A?;
+    MT56A MT56A?;
+    MT57A MT57A;
+    MT58A MT58A?;
+|};
+
+# Define the optional general information in the MT300 message.
+#
+# + MT15C - New Sequence  
+# + MT29A - Contact Information  
+# + MT24D - Dealing Method  
+# + MT84A - Dealing Branch Party A  
+# + MT85A - Dealing Branch Party B  
+# + MT88A - Broker Identification  
+# + MT71F - Broker's Commission  
+# + MT26H - Counterparty's Reference  
+# + MT21G - Broker's Reference  
+# + MT72 - Sender to Receiver Information
+public type MT300OptionalGeneralInformation record {|
+    MT15C MT15C;
+    MT29A MT29A?;
+    MT24D MT24D?;
+    MT84A MT84A?;
+    MT85A MT85A?;
+    MT88A MT88A?;
+    MT71F MT71F?;
+    MT26H MT26H?;
+    MT21G MT21G?;
+    MT72 MT72?;
+|};
+
+# Define the split settlement details in the MT300 message.
+#
+# + MT15D - New Sequence  
+# + MT17A - Buy (Sell) Indicator 
+# + MT32B - Currency, Amount  
+# + MT53A - Delivery Agent  
+# + MT56A - Intermediary  
+# + MT57A - Receiving Agent  
+# + MT58A - Beneficiary Institution  
+# + MT16A - Number of Settlements
+public type MT300SplitSettlementDetails record {|
+    MT15D MT15D;
+    MT17A MT17A;
+    MT32B MT32B;
+    MT53A MT53A?;
+    MT56A MT56A?;
+    MT57A MT57A;
+    MT58A MT58A?;
+    MT16A MT16A;
+|};
+
+# Define the reporting information in the MT300 message.
+#
+# + MT15E - New Sequence  
+# + ReportingParties - An array of Reporting Parties  
+# + MT81A - Central Counterparty Clearing House (CCP)  
+# + MT89A - Clearing Broker  
+# + MT96A - Clearing Exception Party  
+# + MT22S - Clearing Broker Identification  
+# + MT22T - Cleared Product Identification  
+# + MT17E - Clearing Threshold Indicator  
+# + MT22U - Unique Product Identifier  
+# + MT35B - Identification of Financial Instrument  
+# + MT17H - Allocation Indicator  
+# + MT17P - Collateralisation Indicator  
+# + MT22V - Execution Venue  
+# + MT98D - Execution Timestamp  
+# + MT17W - Non Standard Flag  
+# + MT22W - Link Swap Identification  
+# + MT17Y - Financial Nature of the Counterparty Indicator  
+# + MT17Z - Collateral Portfolio Indicator  
+# + MT22Q - Collateral Portfolio Code  
+# + MT17L - Portfolio Compression Indicator  
+# + MT17M - Corporate Sector Indicator  
+# + MT17Q - Trade with Non-EEA Counterparty Indicator  
+# + MT17S - Intragroup Trade Indicator  
+# + MT17X - Commercial or Treasury Financing Indicator  
+# + MT98G - Confirmation Timestamp  
+# + MT98H - Clearing Timestamp  
+# + MT34C - Commission and Fees  
+# + MT77A - Additional Reporting Information
+public type MT300ReportingInformation record {|
+    MT15E MT15E;
+    MT300ReportingParties[] ReportingParties?;
+    MT81A MT81A?;
+    MT89A MT89A?;
+    MT96A MT96A?;
+    MT22S MT22S?;
+    MT22T MT22T?;
+    MT17E MT17E?;
+    MT22U MT22U?;
+    MT35B MT35B?;
+    MT17H MT17H?;
+    MT17P MT17P?;
+    MT22V MT22V?;
+    MT98D MT98D?;
+    MT17W MT17W?;
+    MT22W MT22W?;
+    MT17Y MT17Y?;
+    MT17Z MT17Z?;
+    MT22Q MT22Q?;
+    MT17L MT17L?;
+    MT17M MT17M?;
+    MT17Q MT17Q?;
+    MT17S MT17S?;
+    MT17X MT17X?;
+    MT98G MT98G?;
+    MT98H MT98H?;
+    MT34C MT34C?;
+    MT77A MT77A?;
+|};
+
+# Define the reporting parties in the MT300ReportingInformation element.
+#
+# + MT22L - Reporting Jurisdiction  
+# + MT91A - Reporting Party  
+# + UniqueTransactionIdentifier - Unique Transaction Identifier
+public type MT300ReportingParties record {|
+    MT22L MT22L;
+    MT91A MT91A?;
+    MT300UniqueTransactionIdentifier UniqueTransactionIdentifier?;
+|};
+
+# Define the unique transaction identifier in the MT300ReportingParties element.
+#
+# + MT22M - UTI Namespace/Issuer Code  
+# + MT22N - Transaction Identifier  
+# + PriorUniqueTransactionIdentifier - Prior Unique Transaction Identifier
+public type MT300UniqueTransactionIdentifier record {|
+    MT22M MT22M;
+    MT22N MT22N;
+    MT300PriorUniqueTransactionIdentifier PriorUniqueTransactionIdentifier?;
+|};
+
+# Define the prior unique transaction identifier in the MT300UniqueTransactionIdentifier element.
+#
+# + MT22P - PUTI Namespace/Issuer Code  
+# + MT22R - Prior Transaction Identifier
+public type MT300PriorUniqueTransactionIdentifier record {|
+    MT22P MT22P;
+    MT22R MT22R;
+|};
+
+# Define the post trade events in the MT300 message.
+#
+# + MT15F - New Sequence 
+# + MT21H - Event Type and Reference  
+# + MT21F - Underlying Liability Reference  
+# + MT30F - Profit and Loss Settlement Date  
+# + MT32H - Profit and Loss Settlement Amount  
+# + MT33E - Outstanding Settlement Amount
+public type MT300PostTradeEvents record {|
+    MT15F MT15F;
+    MT21H MT21H;
+    MT21F MT21F?;
+    MT30F MT30F?;
+    MT32H MT32H?;
+    MT33E MT33E?;
+|};

--- a/swiftmt/304_advice_or_instruction_of_a_third_party_deal.bal
+++ b/swiftmt/304_advice_or_instruction_of_a_third_party_deal.bal
@@ -1,0 +1,227 @@
+// Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# Defines the structure of an MT304 message.
+#
+# + block1 - Basic Header Block 
+# + block2 - Application Header Block
+# + block3 - User Header Block 
+# + block4 - Text Block containing Advice/Instruction of a Third Party Deal 
+# + block5 - Trailer Block 
+# + UnparsedTexts - Any additional unparsed texts
+public type MT304Message record {|
+    Block1 block1?;
+    Block2 block2;
+    Block3 block3?;
+    MT304Block4 block4;
+    Block5 block5?;
+    UnparsedTexts UnparsedTexts?;
+|};
+
+# Defines the elements of the MT304 message block 4.
+#
+# + MT15A - New Sequence  
+# + MT20 - Sender's Reference  
+# + MT21 - Related Reference  
+# + MT22A - Type of Operation  
+# + MT94A - Scope of Operation  
+# + MT17O - Open Indicator  
+# + MT17F - Final Close Indicator  
+# + MT17N - Net Settlement Indicator  
+# + MT83A - Fund  
+# + MT82A - Fund Manager  
+# + MT87A - Executing Broker  
+# + MT81A - Central Counterparty Clearing House (CCP)  
+# + MT89A - Clearing Broker  
+# + MT17I - Payment versus Payment Settlement Indicator  
+# + MT77H - Type, Date, Version of Agreement  
+# + MT14C - Year of Definitions  
+# + MT32E - Settlement Currency  
+# + MT30U - Valuation Date  
+# + MT14S - Settlement Rate Source  
+# + MT26K - Calculation Agent  
+# + MT21A - Reference to Opening Instruction  
+# + MT14E - Clearing or Settlement Session  
+# + ForexTransaction - Forex Transaction Details  
+# + OptionalGeneralInformation - Optional General Information  
+# + AccountingInformation - Accounting Information  
+# + NetAmountToBeSettled - Net Amount To Be Settled
+public type MT304Block4 record {|
+    MT15A MT15A;
+    MT20 MT20;
+    MT21 MT21?;
+    MT22A MT22A;
+    MT94A MT94A;
+    MT17O MT17O?;
+    MT17F MT17F?;
+    MT17N MT17N?;
+    MT83A MT83A;
+    MT82A MT82A;
+    MT87A MT87A;
+    MT81A MT81A?;
+    MT89A MT89A?;
+    MT17I MT17I?;
+    MT77H MT77H?;
+    MT14C MT14C?;
+    MT32E MT32E?;
+    MT30U MT30U?;
+    MT14S MT14S?;
+    MT26K MT26K?;
+    MT21A MT21A?;
+    MT14E MT14E?;
+    MT304ForexTransaction ForexTransaction;
+    MT304OptionalGeneralInformation OptionalGeneralInformation?;
+    MT304AccountingInformation AccountingInformation?;
+    MT304NetAmountToBeSettled NetAmountToBeSettled?;
+|};
+
+# Define the forex transacion details in the MT304 message.
+#
+# + MT15B - New Sequence  
+# + MT30T - Trade Date  
+# + MT30V - Value Date  
+# + MT36 - Exchange Rate  
+# + MT39M - Payment Clearing Centre  
+# + MT35C - Digutal Token Identifier  
+# + AmountBought - Amount bought details  
+# + AmountSold - Amount sold details
+public type MT304ForexTransaction record {|
+    MT15B MT15B;
+    MT30T MT30T;
+    MT30V MT30V;
+    MT36 MT36;
+    MT39M MT39M?;
+    MT35C MT35C?;
+    MT304AmountBought AmountBought;
+    MT304AmountSold AmountSold;
+|};
+
+# Define the amount bought details in the MT304ForexTransaction element.
+#
+# + MT32B - Currency, Amount  
+# + MT53A - Delivery Agent  
+# + MT56A - Intermediary  
+# + MT57A - Receiving Agent
+public type MT304AmountBought record {|
+    MT32B MT32B;
+    MT53A MT53A;
+    MT56A MT56A?;
+    MT57A MT57A?;
+|};
+
+# Define the amount sold details in the MT304ForexTransaction element.
+#
+# + MT33B - Currency, Amount Sold
+# + MT53A - Delivery Agent
+# + MT56A - Intermediary
+# + MT57A - Receiving Agent
+# + MT58A - Beneficiary Institution
+public type MT304AmountSold record {|
+    MT33B MT33B;
+    MT53A MT53A?;
+    MT56A MT56A?;
+    MT57A MT57A;
+    MT58A MT58A?;
+|};
+
+# Define the optional general information in the MT304 message.
+#
+# + MT15C - New Sequence  
+# + MT21A - Reference to the Associated Trade  
+# + MT21G - Executing Broker's Reference 
+# + UniqueTransactionIdentifier - An array of unique transaction identifiers  
+# + MT22U - Unique Product Identifier  
+# + MT35B - Identification of the Financial Instrument
+# + MT22V - Execution Venue  
+# + MT98D - Execution Timestamp  
+# + MT98G - Confirmation Timestamp
+# + MT98H - Clearing Timestamp
+# + MT29A - Contact Information 
+# + MT34C - Commission and Fees
+# + MT72 - Sender to Receiver Information
+public type MT304OptionalGeneralInformation record {|
+    MT15C MT15C;
+    MT21A MT21A?;
+    MT21G MT21G?;
+    MT304UniqueTransactionIdentifier[] UniqueTransactionIdentifier?;
+    MT22U MT22U?;
+    MT35B MT35B?;
+    MT22V MT22V?;
+    MT98D MT98D?;
+    MT98G MT98G?;
+    MT98H MT98H?;
+    MT29A MT29A?;
+    MT34C MT34C?;
+    MT72 MT72?;
+|};
+
+# Define the unique transaction identifier in the MT304OptionalGeneralInformation element.
+#
+# + MT22L - Reporting Jurisdiction  
+# + MT22M - UTI Namespace/Issuer Code
+# + MT22N - Transaction Identifier
+# + MT304PriorUniqueTransactionIdentifier - An array of prior unique transaction identifiers
+public type MT304UniqueTransactionIdentifier record {|
+    MT22L MT22L;
+    MT22M MT22M;
+    MT22N MT22N;
+    MT304PriorUniqueTransactionIdentifier[] MT304PriorUniqueTransactionIdentifier?;
+|};
+
+# Define the prior unique transaction identifier in the MT304UniqueTransactionIdentifier element.
+#
+# + MT22P - PUTI Namespace/Issuer Code  
+# + MT22R - Prior Transaction Identifier
+public type MT304PriorUniqueTransactionIdentifier record {|
+    MT22P MT22P;
+    MT22R MT22R;
+|};
+
+# Define the accounting information in the MT304 message.
+#
+# + MT15D - New Sequence
+# + MT21P - Reference to the Previous Deal 
+# + MT17G - Gain (Loss) Indicator
+# + MT32G - Currency, Amount
+# + MT34B - Commission and Fees - Currency and Amount  
+# + MT30F - Commission and Fees - Settlement Date
+public type MT304AccountingInformation record {|
+    MT15D MT15D;
+    MT21P MT21P?;
+    MT17G MT17G?;
+    MT32G MT32G?;
+    MT34B MT34B?;
+    MT30F MT30F?;
+|};
+
+# Define the net amount to be settled in the MT304 message.
+#
+# + MT15E - New Sequence
+# + MT17G - Gain (Loss) Indicator  
+# + MT32G - Currency, Amount
+# + MT53A - Delivery Agent  
+# + MT56A - Intermediary  
+# + MT57A - Receiving Agent  
+# + MT58A - Beneficiary Institution
+public type MT304NetAmountToBeSettled record {|
+    MT15E MT15E;
+    MT17G MT17G;
+    MT32G MT32G;
+    MT53A MT53A?;
+    MT56A MT56A?;
+    MT57A MT57A?;
+    MT58A MT58A?;
+|};

--- a/swiftmt/305_foreign_currency_option_confirmation.bal
+++ b/swiftmt/305_foreign_currency_option_confirmation.bal
@@ -1,0 +1,187 @@
+// Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# Defines the structure of an MT305 message.
+#
+# + block1 - Basic Header Block 
+# + block2 - Application Header Block
+# + block3 - User Header Block 
+# + block4 - Text Block containing Foreign Currency Option Confirmation details
+# + block5 - Trailer Block 
+# + UnparsedTexts - Any additional unparsed texts
+public type MT305Message record {|
+    Block1 block1?;
+    Block2 block2;
+    Block3 block3?;
+    MT305Block4 block4;
+    Block5 block5?;
+    UnparsedTexts UnparsedTexts?;
+|};
+
+# Defines the elements of the MT305 message block 4.
+#
+# + MT15A - New Sequence
+# + MT20 - Transaction Reference Number  
+# + MT21 - Related Reference
+# + MT22 - Code/Common Reference  
+# + MT23 - Further Identification
+# + MT94A - Scope of Operation
+# + MT82A - Party A 
+# + MT87A - Party B
+# + MT83A - Fund or Beneficiary Customer
+# + MT30 - Date Contract Agreed/Amended
+# + MT31C - Earliest Exercise Date
+# + MT31G - Expiry Date
+# + MT31E - Final Settlement Date  
+# + MT26F - Settlement Type
+# + MT39M - Payment Clearing Centre  
+# + MT17F - Non-Deliverable Indicator
+# + MT14S - Settlement Rate Source
+# + MT32E - Settlement Currency
+# + MT35C - Digital Token Identifier
+# + MT26K - Calculation Agent  
+# + MT32B - Underlying Currency and Amount  
+# + MT36 - Strike Price
+# + MT33B - Counter Currency and Amount  
+# + MT37K - Premium Price
+# + MT34A - Premium Payment   
+# + MT53A - Sender's Correspondent  
+# + MT56A - Intermediary  
+# + MT57A - Account With Institution  
+# + MT77H - Type, Date, Version of the Agreement  
+# + MT14C - Year of Definitions  
+# + MT72 - Sender to Receiver Information  
+# + ReportingInformation - Reporting Information
+public type MT305Block4 record {|
+    MT15A MT15A;
+    MT20 MT20;
+    MT21 MT21;
+    MT22 MT22;
+    MT23 MT23;
+    MT94A MT94A?;
+    MT82A MT82A;
+    MT87A MT87A;
+    MT83A MT83A?;
+    MT30 MT30;
+    MT31C MT31C?;
+    MT31G MT31G;
+    MT31E MT31E;
+    MT26F MT26F;
+    MT39M MT39M?;
+    MT17F MT17F?;
+    MT14S MT14S?;
+    MT32E MT32E?;
+    MT35C MT35C?;
+    MT26K MT26K?;
+    MT32B MT32B;
+    MT36 MT36;
+    MT33B MT33B;
+    MT37K MT37K;
+    MT34A MT34A;
+    MT53A MT53A?;
+    MT56A MT56A?;
+    MT57A MT57A;
+    MT77H MT77H?;
+    MT14C MT14C?;
+    MT72 MT72?;
+    MT305ReportingInformation ReportingInformation?;
+|};
+
+# Defines the structure of the Reporting Information in the MT305 message.
+#
+# + MT15B - New Sequence  
+# + ReportingParties - Array of Reporting Parties  
+# + MT81A - Central Counterparty Clearing House (CCP)  
+# + MT89A - Clearing Broker  
+# + MT96A - Clearing Execption Party  
+# + MT22S - Clearing Broker Identification  
+# + MT22T - Cleared Product Identification  
+# + MT17E - Clearing Threshold Indicator  
+# + MT22U - Unique Product Identifier 
+# + MT35B - Identification of Financial Instrument
+# + MT17H - Allocation Indicator
+# + MT17P - Collateralisation Indicator
+# + MT22V - Execution Venue
+# + MT98D - Execution Timestamp  
+# + MT17W - Non Standard Flag
+# + MT17Y - Financial Nature of the Counterparty Indicator  
+# + MT17Z - Collateral Portfolio Indicator
+# + MT22Q - Collateral Portfolio Code
+# + MT17L - Portfolio Compression Indicator
+# + MT17M - Corporate Sector Indicator
+# + MT17Q - Trade with Non-EEA Counterparty Indicator
+# + MT17S - Intragroup Trade Indicator
+# + MT17X - Commercial or Treasury Financing Indicator
+# + MT34C - Commission and Fees
+# + MT77A - Additional Reporting Information
+public type MT305ReportingInformation record {|
+    MT15B MT15B;
+    MT305ReportingParties[] ReportingParties?;
+    MT81A MT81A?;
+    MT89A MT89A?;
+    MT96A MT96A?;
+    MT22S MT22S?;
+    MT22T MT22T?;
+    MT17E MT17E?;
+    MT22U MT22U?;
+    MT35B MT35B?;
+    MT17H MT17H?;
+    MT17P MT17P?;
+    MT22V MT22V?;
+    MT98D MT98D?;
+    MT17W MT17W?;
+    MT17Y MT17Y?;
+    MT17Z MT17Z?;
+    MT22Q MT22Q?;
+    MT17L MT17L?;
+    MT17M MT17M?;
+    MT17Q MT17Q?;
+    MT17S MT17S?;
+    MT17X MT17X?;
+    MT34C MT34C?;
+    MT77A MT77A?;
+|};
+
+# Defines the structure of the Reporting Parties in the MT305ReportingInformation element.
+#
+# + MT22L - Reporting Jurisdiction  
+# + MT91A - Reporting Party
+# + UniqueTransactionIdentifier - Array of Unique Transaction Identifiers
+public type MT305ReportingParties record {|
+    MT22L MT22L;
+    MT91A MT91A?;
+    MT305UniqueTransactionIdentifier[] UniqueTransactionIdentifier?;
+|};
+
+# Defines the structure of the Unique Transaction Identifier in the MT305ReportingParties element.
+#
+# + MT22M - UTI Namespace/Issuer Code 
+# + MT22N - Transaction Identifier
+# + PriorUniqueTransactionIdentifier - Array of Prior Unique Transaction Identifiers
+public type MT305UniqueTransactionIdentifier record {|
+    MT22M MT22M;
+    MT22N MT22N;
+    MT305PriorUniqueTransactionIdentifier[] PriorUniqueTransactionIdentifier?;
+|};
+
+# Defines the structure of the Prior Unique Transaction Identifier in the MT305UniqueTransactionIdentifier element.
+#
+# + MT22P - PUTI Namespace/Issuer Code  
+# + MT22R - Prior Transaction Identifier
+public type MT305PriorUniqueTransactionIdentifier record {|
+    MT22P MT22P;
+    MT22R MT22R;
+|};

--- a/swiftmt/306_foreign_currency_option_confirmation.bal
+++ b/swiftmt/306_foreign_currency_option_confirmation.bal
@@ -1,0 +1,483 @@
+// Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# Defines the structure of an MT306 message.
+#
+# + block1 - Basic Header Block 
+# + block2 - Application Header Block
+# + block3 - User Header Block 
+# + block4 - Text Block containing Foreign Currency Option Confirmation details
+# + block5 - Trailer Block 
+# + UnparsedTexts - Any additional unparsed texts
+public type MT306Message record {|
+    Block1 block1?;
+    Block2 block2;
+    Block3 block3?;
+    MT306Block4 block4;
+    Block5 block5?;
+    UnparsedTexts UnparsedTexts?;
+|};
+
+# Defines the elements of the MT306 message block 4.
+#
+# + MT15A - New Sequence  
+# + MT20 - Sender's Reference  
+# + MT21 - Related Reference 
+# + MT22A - Type of Operation  
+# + MT94A - Scope of Operation  
+# + MT22C - Common Reference 
+# + MT21N - Contract Number Party A  
+# + MT21B - Contract Number Party B
+# + MT12F - Option or Forward Style
+# + MT12E - Expiration Style
+# + MT12D - Option Style  
+# + MT17A - Barrier Indicator  
+# + MT17F - Non-Deliverable Indicator 
+# + MT22K - Type of Event
+# + MT30U - Date of Barrier Event  
+# + MT29H - Location of Barrier Event
+# + MT82A - Party A
+# + MT87A - Party B  
+# + MT83A - Fund or Beneficiary Customer  
+# + MT77H - Type, Date, Version of Agreement
+# + MT77D - Additional Conditions
+# + MT14C - Year of Definitions
+# + Transaction - Transaction details  
+# + SettInstPayPre - Settlement Instructions for Payment of Premium
+# + VanillaOp - Vanilla Option or Forward Block 
+# + BinPayAmnt - Binary Payout Amount 
+# + BarrBlock - Barrier Block 
+# + BinBlock - Binary Block  
+# + NonDeliBlock - Non Deliverable Block  
+# + EarlyTerm - Early Termination  
+# + AveOptnForw - Averaging Options and Forwards  
+# + AddiInfo - Additional Information  
+# + AddiAmnt - Additional Amounts  
+# + RepInfo - Reporting Information
+public type MT306Block4 record {|
+    MT15A MT15A;
+    MT20 MT20;
+    MT21 MT21?;
+    MT22A MT22A;
+    MT94A MT94A?;
+    MT22C MT22C;
+    MT21N MT21N;
+    MT21B MT21B?;
+    MT12F MT12F;
+    MT12E MT12E?;
+    MT12D MT12D?;
+    MT17A MT17A?;
+    MT17F MT17F;
+    MT22K MT22K;
+    MT30U MT30U?;
+    MT29H MT29H?;
+    MT82A MT82A;
+    MT87A MT87A;
+    MT83A MT83A?;
+    MT77H MT77H;
+    MT77D MT77D?;
+    MT14C MT14C?;
+    MT306Transaction Transaction;
+    MT306SettInstPayPre SettInstPayPre?;
+    MT306VanillaOpt VanillaOp?;
+    MT306BinPayAmnt BinPayAmnt?;
+    MT306BarrBlock BarrBlock?;
+    MT306BinBlock BinBlock?;
+    MT306NonDeliBlock NonDeliBlock?;
+    MT306EarlyTerm EarlyTerm?;
+    MT306AveOptnForw AveOptnForw?;
+    MT306AddiInfo AddiInfo?;
+    MT306AddiAmnt AddiAmnt?;
+    MT306RepInfo RepInfo?;
+|};
+
+# Defines the structure of the Transaction Information in the MT306 message.
+#
+# + MT15B - New Sequence  
+# + MT17V - Buy (Sell) Indicator 
+# + MT30T - Trade Date
+# + MT30X - Expiration or Valuation Date  
+# + MT29A - Expiration or Valuation Location and Time
+# + MT30A - Final Settlement Date
+# + MT29H - Payment Business Day
+# + MT14S - Settlement Rate Source  
+# + MT39M - Payment Clearing Centre
+# + PremDetails - Premium Details  
+# + CalcAgent - Calculation Agent
+public type MT306Transaction record {|
+    MT15B MT15B;
+    MT17V MT17V?;
+    MT30T MT30T;
+    MT30X MT30X;
+    MT29A MT29A;
+    MT30A MT30A;
+    MT29H MT29H?;
+    MT14S MT14S?;
+    MT39M MT39M?;
+    MT306PremDetails PremDetails?;
+    MT306CalcAgent CalcAgent;
+|};
+
+# Defines the structure of the Premium Details in the MT306Transaction element.
+#
+# + MT37K - Premium Price  
+# + MT30V - Premium Payment Date  
+# + MT34B - Premium Currency and Amount
+public type MT306PremDetails record {|
+    MT37K MT37K?;
+    MT30V MT30V;
+    MT34B MT34B;
+|};
+
+# Defines the structure of the Calculation Agent Details in the MT306Transaction element.
+#
+# + MT84A - Calculation Agent
+public type MT306CalcAgent record {|
+    MT84A MT84A;
+|};
+
+# Defines the structure of the Settlement Instructions for Payment of Premium in the MT306 message.
+#
+# + MT15C - New Sequence  
+# + MT53A - Delivery Agent  
+# + MT86A - Intermediary 2  
+# + MT56A - Intermediary  
+# + MT57A - Receiving Agent  
+# + MT58A - Beneficiary Institution
+public type MT306SettInstPayPre record {|
+    MT15C MT15C;
+    MT53A MT53A?;
+    MT86A MT86A?;
+    MT56A MT56A?;
+    MT57A MT57A;
+    MT58A MT58A?;
+|};
+
+# Defines the structure of the Vanilla Option or Forward Block in the MT306 message.
+#
+# + MT15D - New Sequence  
+# + MT30P - Earliest Exercise Date  
+# + MT30Q - Intermediate Exercise Date
+# + MT26F - Settlement Type
+# + MT32B - Put Currency and Amount or Party A Sold Currency and Amount   
+# + MT36 - Strike Price or Forward Rate  
+# + MT33B - Call Currency and Amount or Party A Bought Currency and Amount
+public type MT306VanillaOpt record {|
+    MT15D MT15D;
+    MT30P MT30P?;
+    MT30Q MT30Q?;
+    MT26F MT26F;
+    MT32B MT32B;
+    MT36 MT36;
+    MT33B MT33B;
+|};
+
+# Defines the structure of the Binary Payout Amount in the MT306 message.
+#
+# + MT15E - New Sequence  
+# + MT33E - Currency, Amount  
+# + MT30H - Binary Amount Payment Date  
+# + MT53A - Delivery Agent
+# + MT86A - Intermediary 2  
+# + MT56A - Intermediary  
+# + MT57A - Receiving Agent  
+# + MT58A - Beneficiary Institution
+public type MT306BinPayAmnt record {|
+    MT15E MT15E;
+    MT33E MT33E;
+    MT30H MT30H?;
+    MT53A MT53A?;
+    MT86A MT86A?;
+    MT56A MT56A?;
+    MT57A MT57A;
+    MT58A MT58A?;
+|};
+
+# Defines the structure of the Barrier Block in the MT306 message.
+#
+# + MT15F - New Sequence  
+# + MT22G - Type of Barrier  
+# + MT17C - Barrier Event Equal Modifier  
+# + MT37J - Barrier Level
+# + MT37L - Lower Barrier Level  
+# + MT14S - Barrier Settlement Rate Source
+# + MT29I - Barrier Determination Business Days
+# + MT14H - All Barrier Dates Business Day Convention
+# + MT14K - Interim Barrier Dates Business Day Convention  
+# + MT14L - Barrier Event End Date Business Day Convention  
+# + MT14M - Barrier Time Type
+# + MT29O - Continuous Time Period  
+# + MT14N - Spot Market   
+# + MT29J - Barrier Event Determination Time  
+# + MT14O - Barrier Event Determination Time Source  
+# + MT33Z - Rebate Amount   
+# + MT30A - Rebate Amount Payment Date  
+# + MT84A - Barrier Determination Agent  
+# + BarrWinBlock - Barrier Window Block
+public type MT306BarrBlock record {|
+    MT15F MT15F;
+    MT22G MT22G;
+    MT17C MT17C?;
+    MT37J MT37J;
+    MT37L MT37L?;
+    MT14S MT14S?;
+    MT29I MT29I?;
+    MT14H MT14H?;
+    MT14K MT14K?;
+    MT14L MT14L?;
+    MT14M MT14M;
+    MT29O MT29O?;
+    MT14N MT14N?;
+    MT29J MT29J?;
+    MT14O MT14O?;
+    MT33Z MT33Z?;
+    MT30A MT30A?;
+    MT84A MT84A?;
+    MT306barrWinBlock[] BarrWinBlock?;
+|};
+
+# Defines the structure of the Barrier Window Block in the MT306BarrBlock element.
+#
+# + MT30I - Barrier Monitoring Period
+public type MT306barrWinBlock record {|
+    MT30I MT30I;
+|};
+
+# Defines the structure of the Binary Block in the MT306 message.
+#
+# + MT15G - New Sequence 
+# + MT32Q - Currency Pair
+public type MT306BinBlock record {|
+    MT15G MT15G;
+    MT32Q MT32Q;
+|};
+
+# Defines the structure of the Non Deliverable Block in the MT306 message.
+#
+# + MT15H - New Sequence
+# + MT14S - Settlement Rate Source  
+# + MT32E - Settlement Currency  
+# + MT26K - Calculation Agent  
+# + MT35C - Digital Token Identifier
+public type MT306NonDeliBlock record {|
+    MT15H MT15H;
+    MT14S MT14S;
+    MT32E MT32E;
+    MT26K MT26K?;
+    MT35C MT35C?;
+|};
+
+# Defines the structure of the Early Termination in the MT306 message.
+#
+# + MT15I - New Sequence  
+# + MT12G - Early Termination Style  
+# + MT30T - Early Termination Date
+# + MT22Y - Frequency of Early Termination
+# + MT85A - Exercising Party
+# + MT88A - Non-Exercising Party  
+# + MT84A - Calculation Agent
+# + MT30Y - Commencement Date  
+# + MT29L - Expiry Details  
+# + MT29E - Earliest Exercise Time  
+# + MT29M - Latest Exercise Time  
+# + MT17I - Cash Settlement
+# + MT29N - Cash Settlement Valuation Details  
+# + MT30Z - Cash Settlement Payment Date
+# + MT14S - Settlement Rate Source
+public type MT306EarlyTerm record {|
+    MT15I MT15I;
+    MT12G MT12G;
+    MT30T MT30T?;
+    MT22Y MT22Y?;
+    MT85A MT85A?;
+    MT88A MT88A?;
+    MT84A MT84A;
+    MT30Y MT30Y?;
+    MT29L MT29L?;
+    MT29E MT29E?;
+    MT29M MT29M?;
+    MT17I MT17I?;
+    MT29N MT29N?;
+    MT30Z MT30Z?;
+    MT14S MT14S?;
+|};
+
+# Defines the structure of the Averaging Options and Forwards in the MT306 message.
+#
+# + MT15J - New Sequence 
+# + MT14P - Averaging Method
+# + MT14S - Settlement Rate Source  
+# + MT29Q - Valuation Business Days  
+# + MT14R - Averaging Date Business Day Convention  
+# + MT14Q - Averaging Date Disruption Consequence  
+# + MT16A - Maximum Days of Postponement  
+# + MT14B - Adjustment Type  
+# + MT19C - Adjestment Factor  
+# + SettRate - Settlement Rate
+# + ForwRate - Forward Rate or Strike Price
+public type MT306AveOptnForw record {|
+    MT15J MT15J;
+    MT14P MT14P?;
+    MT14S MT14S?;
+    MT29Q MT29Q?;
+    MT14R MT14R?;
+    MT14Q MT14Q?;
+    MT16A MT16A?;
+    MT14B MT14B?;
+    MT19C MT19C?;
+    MT306SettRate[] SettRate?;
+    MT306ForwRate[] ForwRate?;
+|};
+
+# Defines the structure of the Settlement Rate Details in the MT306AveOptnForw element.
+#
+# + MT30I - Settlement Rate Averaging Period  
+# + MT19Y - Weight
+public type MT306SettRate record {|
+    MT30I MT30I;
+    MT19Y MT19Y?;
+|};
+
+# Defines the structure of the Forward Rate or Strike Price in the MT306AveOptnForw element.
+#
+# + MT30K - Forward Rate or Strike Price Averaging Period  
+# + MT19Z - Weight
+public type MT306ForwRate record {|
+    MT30K MT30K;
+    MT19Z MT19Z?;
+|};
+
+# Defines the structure of the Additional Information in the MT306 message.
+#
+# + MT15K - New Sequence  
+# + MT29A - Contract Information  
+# + MT24D - Dealing Method
+# + MT88A - Broker Identification  
+# + MT71F - Broker's Commission
+# + MT21G - Broker's Reference
+# + MT72 - Sender to Receiver Information
+public type MT306AddiInfo record {|
+    MT15K MT15K;
+    MT29A MT29A?;
+    MT24D MT24D?;
+    MT88A MT88A?;
+    MT71F MT71F?;
+    MT21G MT21G?;
+    MT72 MT72?;
+|};
+
+# Defines the structure of the Additional Amounts in the MT306 message.
+#
+# + MT15L - New Sequence  
+# + MT18A - Number of Repetitions  
+# + MT30F - Payment Date
+# + MT32H - Currency, Payment Amount  
+# + MT53A - Delivery Agent
+# + MT86A - Intermediary 2  
+# + MT56A - Intermediary  
+# + MT57A - Receiving Agent
+public type MT306AddiAmnt record {|
+    MT15L MT15L;
+    MT18A MT18A;
+    MT30F MT30F;
+    MT32H MT32H;
+    MT53A MT53A?;
+    MT86A MT86A?;
+    MT56A MT56A?;
+    MT57A MT57A;
+|};
+
+# Defines the structure of the Reporting Information in the MT306 message.
+#
+# + MT15M - New Sequence  
+# + RepParties - Reporting Parties
+# + MT96A - Clearing Exception Party  
+# + MT22S - Clearing Broker Identification  
+# + MT22T - Cleared Product Identification  
+# + MT17E - Clearing Threshold Indicator 
+# + MT22U - Unique Product Identifier  
+# + MT35B - Identification of Financial Instrument  
+# + MT17H - Allocation Indicator
+# + MT17P - Collateralisation Indicator
+# + MT22V - Execution Venue
+# + MT98D - Execution Timestamp  
+# + MT17W - Non Standard Flag
+# + MT17Y - Financial Nature of the Counterparty Indicator  
+# + MT17Z - Collateral Portfolio Indicator
+# + MT22Q - Collateral Portfolio Code
+# + MT17L - Portfolio Compression Indicator
+# + MT17M - Corporate Sector Indicator
+# + MT17Q - Trade with Non-EEA Counterparty Indicator
+# + MT17S - Intragroup Trade Indicator
+# + MT17X - Commercial or Treasury Financing Indicator
+# + MT34C - Commission and Fees
+# + MT77A - Additional Reporting Information
+public type MT306RepInfo record {|
+    MT15M MT15M;
+    MT306RepParties[] RepParties?;
+    MT96A MT96A?;
+    MT22S MT22S?;
+    MT22T MT22T?;
+    MT17E MT17E?;
+    MT22U MT22U?;
+    MT35B MT35B?;
+    MT17H MT17H?;
+    MT17P MT17P?;
+    MT22V MT22V?;
+    MT98D MT98D?;
+    MT17W MT17W?;
+    MT17Y MT17Y?;
+    MT17Z MT17Z?;
+    MT22Q MT22Q?;
+    MT17L MT17L?;
+    MT17M MT17M?;
+    MT17Q MT17Q?;
+    MT17S MT17S?;
+    MT17X MT17X?;
+    MT34C MT34C?;
+    MT77A MT77A?;
+|};
+
+# Defines the structure of the Reporting Parties in the MT306RepInfo element.
+#
+# + MT22L - Reporting Jurisdiction  
+# + MT91A - Reporting Party
+# + UniqueTransactionIdentifier - Unique Transaction Identifier
+public type MT306RepParties record {|
+    MT22L MT22L;
+    MT91A MT91A?;
+    MT306UniqueTransactionIdentifier[] UniqueTransactionIdentifier?;
+|};
+
+# Defines the structure of the Unique Transaction Identifier in the MT306RepParties element.
+#
+# + MT22M - UTI Namespace/Issuer Code
+# + MT22N - Transaction Identifier
+# + PriorUniqueTransactionIdentifier - An array of prior unique transaction identifiers
+public type MT306UniqueTransactionIdentifier record {|
+    MT22M MT22M;
+    MT22N MT22N;
+    MT306PriorUniqueTransactionIdentifier[] PriorUniqueTransactionIdentifier?;
+|};
+
+# Defines the structure of the prior unique transaction identifier in the Mt306UniqueTransactionIdentifier element.
+#
+# + MT22P - PUTI Namespace/Issuer Code 
+# + MT22R - Prior Transaction Identifier
+public type MT306PriorUniqueTransactionIdentifier record {|
+    MT22P MT22P;
+    MT22R MT22R;
+|};

--- a/swiftmt/320_fixed_loan_or_deposit_confirmation.bal
+++ b/swiftmt/320_fixed_loan_or_deposit_confirmation.bal
@@ -1,0 +1,241 @@
+// Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# Defines the structure of an MT320 message.
+#
+# + block1 - Basic Header Block 
+# + block2 - Application Header Block
+# + block3 - User Header Block 
+# + block4 - Text Block containing Fixed Loan/Deposit Confirmation details
+# + block5 - Trailer Block 
+# + UnparsedTexts - Any additional unparsed texts
+public type MT320Message record {|
+    Block1 block1?;
+    Block2 block2;
+    Block3 block3?;
+    MT320Block4 block4;
+    Block5 block5?;
+    UnparsedTexts UnparsedTexts?;
+|};
+
+# Defines the elements of the MT320 message block 4.
+#
+# + MT15A - New Sequence  
+# + MT20 - Sender's Reference  
+# + MT21 - Related Reference 
+# + MT22A - Type of Operation  
+# + MT94A - Scope of Operation  
+# + MT22B - Type of Event 
+# + MT22C - Common Reference  
+# + MT21N - Contract Number Party A
+# + MT82A - Party A  
+# + MT87A - Party B  
+# + MT83A - Fund or Instructing Party  
+# + MT77D - Terms and Conditions  
+# + Transaction - Transaction details  
+# + SettlInstAmntPayPartyA - field description  
+# + SettlInstAmntPayPartyB - field description  
+# + SettlInstInterPayPartyA - field description  
+# + SettlInstInterPayPartyB - field description  
+# + TaxInfo - field description  
+# + AddiInfo - field description  
+# + AddiAmnt - field description
+public type MT320Block4 record {|
+    MT15A MT15A;
+    MT20 MT20;
+    MT21 MT21?;
+    MT22A MT22A;
+    MT94A MT94A?;
+    MT22B MT22B;
+    MT22C MT22C;
+    MT21N MT21N?;
+    MT82A MT82A;
+    MT87A MT87A;
+    MT83A MT83A?;
+    MT77D MT77D?;
+    MT320Transaction Transaction;
+    MT320SettlInstAmntPayPartyA SettlInstAmntPayPartyA;
+    MT320SettlInstAmntPayPartyB SettlInstAmntPayPartyB;
+    MT320SettlInstInterPayPartyA SettlInstInterPayPartyA?;
+    MT320SettlInstInterPayPartyB SettlInstInterPayPartyB?;
+    MT320TaxInfo TaxInfo?;
+    MT320AddiInfo AddiInfo?;
+    MT320AddiAmnt AddiAmnt?;
+|};
+
+# Defines the structure of the Transaction Information in the MT320 message.
+#
+# + MT15B - New Sequence  
+# + MT17R - Party A's Role  
+# + MT30T - Trade Date  
+# + MT30V - Value Date  
+# + MT30P - Maturity Date  
+# + MT32B - Currency and Principal Amount 
+# + MT32H - Amount to be Settled  
+# + MT30X - Next Interest Due Date  
+# + MT34E - Currency and Interest Amount  
+# + MT37G - Interest Rate
+# + MT14D - Day Count Fraction  
+# + MT30F - Last Day of the First Interest Period  
+# + MT38J - Number of Days
+# + MT39M - Payment Clearing Centre
+public type MT320Transaction record {|
+    MT15B MT15B;
+    MT17R MT17R;
+    MT30T MT30T;
+    MT30V MT30V;
+    MT30P MT30P;
+    MT32B MT32B;
+    MT32H MT32H?;
+    MT30X MT30X?;
+    MT34E MT34E;
+    MT37G MT37G;
+    MT14D MT14D;
+    MT30F MT30F?;
+    MT38J MT38J?;
+    MT39M MT39M?;
+|};
+
+# Defines the structure of the Settlement Instructions for Amounts Payable by Party A in the MT320 message.
+#
+# + MT15C - New Sequence  
+# + MT53A - Delivery Agent  
+# + MT86A - Intermediary 2  
+# + MT56A - Intermediary  
+# + MT57A - Receiving Agent  
+# + MT58A - Beneficiary Institution
+public type MT320SettlInstAmntPayPartyA record {|
+    MT15C MT15C;
+    MT53A MT53A?;
+    MT86A MT86A?;
+    MT56A MT56A?;
+    MT57A MT57A;
+    MT58A MT58A?;
+|};
+
+# Defines the structure of the Settlement Instructions for Amounts Payable by Party B in the MT320 message.
+#
+# + MT15D - New Sequence  
+# + MT53A - Delivery Agent  
+# + MT86A - Intermediary 2  
+# + MT56A - Intermediary  
+# + MT57A - Receiving Agent  
+# + MT58A - Beneficiary Institution
+public type MT320SettlInstAmntPayPartyB record {|
+    MT15D MT15D;
+    MT53A MT53A?;
+    MT86A MT86A?;
+    MT56A MT56A?;
+    MT57A MT57A;
+    MT58A MT58A?;
+|};
+
+# Defines the structure of the Settlement Instructions for Interests Payable by Party A in the MT320 message.
+#
+# + MT15E - New Sequence  
+# + MT53A - Delivery Agent  
+# + MT86A - Intermediary 2  
+# + MT56A - Intermediary  
+# + MT57A - Receiving Agent  
+# + MT58A - Beneficiary Institution
+public type MT320SettlInstInterPayPartyA record {|
+    MT15E MT15E;
+    MT53A MT53A?;
+    MT86A MT86A?;
+    MT56A MT56A?;
+    MT57A MT57A;
+    MT58A MT58A?;
+|};
+
+# Defines the structure of the Settlement Instructions for Interests Payable by Party B in the MT320 message.
+#
+# + MT15F - New Sequence  
+# + MT53A - Delivery Agent  
+# + MT86A - Intermediary 2  
+# + MT56A - Intermediary  
+# + MT57A - Receiving Agent  
+# + MT58A - Beneficiary Institution
+public type MT320SettlInstInterPayPartyB record {|
+    MT15F MT15F;
+    MT53A MT53A?;
+    MT86A MT86A?;
+    MT56A MT56A?;
+    MT57A MT57A;
+    MT58A MT58A?;
+|};
+
+# Defines the structure of the Tax Information in the MT320 message.
+#
+# + MT15G - New Sequence  
+# + MT37L - Tax Rate  
+# + MT33B - Transaction Currency and Net Interest Amount  
+# + MT36 - Exchange Rate  
+# + MT33E - Reporting Currency and Tax Amount
+public type MT320TaxInfo record {|
+    MT15G MT15G;
+    MT37L MT37L;
+    MT33B MT33B;
+    MT36 MT36?;
+    MT33E MT33E?;
+|};
+
+# Defines the structure of the Additional Information in the MT320 message.
+#
+# + MT15H - New Sequence  
+# + MT29A - Contact Information  
+# + MT24D - Dealing Method
+# + MT84A - Dealing Branch Party A  
+# + MT85A - Dealing Branch Party B
+# + MT88A - Broker Identification
+# + MT71F - Broker's Commission
+# + MT26H - Counterparty's Reference
+# + MT21G - Broker's Reference
+# + MT34C - Commission and Fees 
+# + MT72 - Sender to Receiver Information
+public type MT320AddiInfo record {|
+    MT15H MT15H;
+    MT29A MT29A?;
+    MT24D MT24D?;
+    MT84A MT84A?;
+    MT85A MT85A?;
+    MT88A MT88A?;
+    MT71F MT71F?;
+    MT26H MT26H?;
+    MT21G MT21G?;
+    MT34C MT34C?;
+    MT72 MT72?;
+|};
+
+# Defines the structure of the Additional Amounts in the MT320 message.
+#
+# + MT15I - New Sequence  
+# + MT18A - Number of Repetitions
+# + MT30F - Payment Date  
+# + MT32H - Currency, Payment Amount  
+# + MT53A - Delivery Agent
+# + MT86A - Intermediary 2  
+# + MT56A - Intermediary  
+# + MT57A - Receiving Agent
+public type MT320AddiAmnt record {|
+    MT15I MT15I;
+    MT18A MT18A;
+    MT30F MT30F;
+    MT32H MT32H;
+    MT53A MT53A?;
+    MT86A MT86A?;
+    MT56A MT56A?;
+    MT57A MT57A;
+|};

--- a/swiftmt/321_instruction_to_settle_a_third_party_loan_or_deposit.bal
+++ b/swiftmt/321_instruction_to_settle_a_third_party_loan_or_deposit.bal
@@ -1,0 +1,158 @@
+// Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# Defines the structure of an MT321 message.
+#
+# + block1 - Basic Header Block 
+# + block2 - Application Header Block
+# + block3 - User Header Block 
+# + block4 - Text Block containing Instruction to Settle a Third Party Loan/Deposit
+# + block5 - Trailer Block 
+# + UnparsedTexts - Any additional unparsed texts
+public type MT321Message record {|
+    Block1 block1?;
+    Block2 block2;
+    Block3 block3?;
+    MT321Block4 block4;
+    Block5 block5?;
+    UnparsedTexts UnparsedTexts?;
+|};
+
+# Defines the elements of the MT321 message block 4.
+#
+# + MT16R - Start of Block  
+# + MT20C - Reference  
+# + MT23G - Function of the Message  
+# + MT22H - Indicator
+# + MT99B - Number Count  
+# + Linkages - Linkages  
+# + MT16S - End of Block
+# + LoanDepositDetails - Loan/Deposit Details
+# + SettlDetails - Settlement Details
+public type MT321Block4 record {|
+    MT16R MT16R;
+    MT20C MT20C;
+    MT23G MT23G;
+    MT22H MT22H;
+    MT99B MT99B?;
+    MT321Linkages[] Linkages?;
+    MT16S MT16S;
+    MT321LoanDepositDetails LoanDepositDetails;
+    MT321SettlDetails[] SettlDetails;
+|};
+
+# Defines the elements of MT321Linkages the MT321Block4 element.
+#
+# + MT16R - Start of Block  
+# + MT13A - Linked Message  
+# + MT20C - Reference  
+# + MT16S - End of Block
+public type MT321Linkages record {|
+    MT16R MT16R;
+    MT13A MT13A?;
+    MT20C MT20C;
+    MT16S MT16S;
+|};
+
+# Defines the elements of MT321LoanDepositDetails the MT321Block4 element.
+#
+# + MT16R - Start of Block 
+# + MT20C - Contract Number Reference  
+# + MT22H - Indicator  
+# + MT98A - Date/Time  
+# + MT19A - Amount  
+# + MT92A - Rate  
+# + MT99B - Number Count
+# + MT94C - Payment Clearing Centre
+# + LoanDepositParties1 - Loan/Deposit Parties 1 
+# + LoanDepositParties2 - Loan/Deposit Parties 2
+# + OtherParties - Other Parties
+public type MT321LoanDepositDetails record {|
+    MT16R MT16R;
+    MT20C MT20C;
+    MT22H MT22H;
+    MT98A MT98A;
+    MT19A MT19A;
+    MT92A MT92A;
+    MT99B MT99B?;
+    MT94C MT94C?;
+    MT321LoanDepositParties1 LoanDepositParties1;
+    MT321LoanDepositParties2 LoanDepositParties2;
+    MT321OtherParties OtherParties;
+|};
+
+# Defines the elements of MT321LoanDepositParties1 the MT321LoanDepositDetails element.
+#
+# + MT16R - Start of Block  
+# + MT95A - Loan/Deposit Counterparty
+# + MT16S - End of Block
+public type MT321LoanDepositParties1 record {|
+    MT16R MT16R;
+    MT95A MT95A;
+    MT16S MT16S;
+|};
+
+# Defines the elements of MT321LoanDepositParties2 the MT321LoanDepositDetails element.
+#
+# + MT16R - Start of Block  
+# + MT95A - Investor  
+# + MT97A - Safekeeping Account 
+# + MT16S - End of Block
+public type MT321LoanDepositParties2 record {|
+    MT16R MT16R;
+    MT95A MT95A?;
+    MT97A MT97A;
+    MT16S MT16S;
+|};
+
+# Defines the elements of MT321OtherParties the MT321LoanDepositDetails element.
+#
+# + MT16R - Start of Block 
+# + MT95A - Party  
+# + MT16S - End of Block
+public type MT321OtherParties record {|
+    MT16R MT16R;
+    MT95A MT95A;
+    MT16S MT16S;
+|};
+
+# Defines the elements of MT321SettlDetails the MT321Block4 element.
+#
+# + MT16R - Start of Block  
+# + MT22H - Principal and Interest   
+# + SettlParties - Settlement Parties
+# + MT16S - End of Block
+public type MT321SettlDetails record {|
+    MT16R MT16R;
+    MT22H MT22H;
+    MT321SettlParties[] SettlParties;
+    MT16S MT16S;
+|};
+
+# Defines the elements of MT321SettlParties the MT321SettlDetails element.
+#
+# + MT16R - Start of Block 
+# + MT95A - Party  
+# + MT97A - Cash Account  
+# + MT70C - Party Contact Narrative 
+# + MT16S - End of Block
+public type MT321SettlParties record {|
+    MT16R MT16R;
+    MT95A MT95A;
+    MT97A MT97A?;
+    MT70C MT70C?;
+    MT16S MT16S;
+|};

--- a/swiftmt/330_call_or_notice_loan_deposit_confirmation.bal
+++ b/swiftmt/330_call_or_notice_loan_deposit_confirmation.bal
@@ -1,0 +1,212 @@
+// Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# Defines the structure of an MT330 message.
+#
+# + block1 - Basic Header Block 
+# + block2 - Application Header Block
+# + block3 - User Header Block 
+# + block4 - Text Block containing Call/Notice Loan/Deposit Confirmation details
+# + block5 - Trailer Block 
+# + UnparsedTexts - Any additional unparsed texts
+public type MT330Message record {|
+    Block1 block1?;
+    Block2 block2;
+    Block3 block3?;
+    MT330Block4 block4;
+    Block5 block5?;
+    UnparsedTexts UnparsedTexts?;
+|};
+
+# Defines the elements of the MT330 message block 4.
+#
+# + MT15A - New Sequence
+# + MT20 - Sender's Reference 
+# + MT21 - Related Reference
+# + MT22A - Type of Operation
+# + MT94A - Scope of Operation  
+# + MT22B - Type of Event  
+# + MT22C - Common Reference 
+# + MT21N - Contract Number Party A  
+# + MT82A - Party A  
+# + MT87A - Party B  
+# + MT83A - Fund or Instructing Party
+# + MT77D - Terms and Conditions
+# + Transaction - Transaction Details  
+# + SettlInstAmntPayPartyA - Settlement Instructions for Amounts Payable by Party A  
+# + SettlInstAmntPayPartyB - Settlement Instructions for Amounts Payable by Party B 
+# + SettlInstInterPayPartyA - Settlement Instructions for Interests Payable by Party A 
+# + SettlInstInterPayPartyB - Settlement Instructions for Interests Payable by Party B 
+# + TaxInfo - Tax Information
+# + AddiInfo - Additional Information
+public type MT330Block4 record {|
+    MT15A MT15A;
+    MT20 MT20;
+    MT21 MT21?;
+    MT22A MT22A;
+    MT94A MT94A?;
+    MT22B MT22B;
+    MT22C MT22C;
+    MT21N MT21N?;
+    MT82A MT82A;
+    MT87A MT87A;
+    MT83A MT83A?;
+    MT77D MT77D?;
+    MT330Transaction Transaction;
+    MT330SettlInstAmntPayPartyA SettlInstAmntPayPartyA;
+    MT330SettlInstAmntPayPartyB SettlInstAmntPayPartyB;
+    MT330SettlInstInterPayPartyA SettlInstInterPayPartyA?;
+    MT330SettlInstInterPayPartyB SettlInstInterPayPartyB?;
+    MT330TaxInfo TaxInfo?;
+    MT330AddiInfo AddiInfo?;
+|};
+
+# Defines the structure of the Transaction Information in the MT330 message.
+#
+# + MT15B - New Sequence  
+# + MT17R - Party A's Role  
+# + MT30T - Trade Date  
+# + MT30V - Value Date  
+# + MT38A - Period of Notice  
+# + MT32B - Currency and Balance 
+# + MT32H - Principal Amount to be Settled  
+# + MT30X - Interest Due Date  
+# + MT34E - Currency and Interest Amount  
+# + MT37G - Interest Rate  
+# + MT14D - Day Count Fraction  
+# + MT30F - Last Day of the Next Interest Period  
+# + MT38J - Number of Days  
+# + MT39M - Payment Clearing Centre
+public type MT330Transaction record {|
+    MT15B MT15B;
+    MT17R MT17R;
+    MT30T MT30T;
+    MT30V MT30V;
+    MT38A MT38A;
+    MT32B MT32B?;
+    MT32H MT32H?;
+    MT30X MT30X?;
+    MT34E MT34E?;
+    MT37G MT37G;
+    MT14D MT14D;
+    MT30F MT30F?;
+    MT38J MT38J?;
+    MT39M MT39M?;
+|};
+
+# Defines the structure of the Settlement Instructions for Amounts Payable by Party A in the MT330 message.
+#
+# + MT15C - New Sequence  
+# + MT53A - Delivery Agent  
+# + MT86A - Intermediary 2  
+# + MT56A - Intermediary  
+# + MT57A - Receiving Agent  
+# + MT58A - Beneficiary Institution
+public type MT330SettlInstAmntPayPartyA record {|
+    MT15C MT15C;
+    MT53A MT53A?;
+    MT86A MT86A?;
+    MT56A MT56A?;
+    MT57A MT57A;
+    MT58A MT58A?;
+|};
+
+# Defines the structure of the Settlement Instructions for Amounts Payable by Party B in the MT330 message.
+#
+# + MT15D - New Sequence  
+# + MT53A - Delivery Agent  
+# + MT86A - Intermediary 2  
+# + MT56A - Intermediary  
+# + MT57A - Receiving Agent  
+# + MT58A - Beneficiary Institution
+public type MT330SettlInstAmntPayPartyB record {|
+    MT15D MT15D;
+    MT53A MT53A?;
+    MT86A MT86A?;
+    MT56A MT56A?;
+    MT57A MT57A;
+    MT58A MT58A?;
+|};
+
+# Defines the structure of the Settlement Instructions for Interests Payable by Party A in the MT330 message.
+#
+# + MT15E - New Sequence  
+# + MT53A - Delivery Agent  
+# + MT86A - Intermediary 2  
+# + MT56A - Intermediary  
+# + MT57A - Receiving Agent  
+# + MT58A - Beneficiary Institution
+public type MT330SettlInstInterPayPartyA record {|
+    MT15E MT15E;
+    MT53A MT53A?;
+    MT86A MT86A?;
+    MT56A MT56A?;
+    MT57A MT57A;
+    MT58A MT58A?;
+|};
+
+# Defines the structure of the Settlement Instructions for Interests Payable by Party B in the MT330 message.
+#
+# + MT15F - New Sequence  
+# + MT53A - Delivery Agent  
+# + MT86A - Intermediary 2  
+# + MT56A - Intermediary  
+# + MT57A - Receiving Agent  
+# + MT58A - Beneficiary Institution
+public type MT330SettlInstInterPayPartyB record {|
+    MT15F MT15F;
+    MT53A MT53A?;
+    MT86A MT86A?;
+    MT56A MT56A?;
+    MT57A MT57A;
+    MT58A MT58A?;
+|};
+
+# Defines the structure of the Tax Information in the MT330 message.
+#
+# + MT15G - New Sequence  
+# + MT37L - Tax Rate  
+# + MT33B - Transaction Currency and Net Interest Amount  
+# + MT36 - Exchange Rate  
+# + MT33E - Reporting Currency and Tax Amount
+public type MT330TaxInfo record {|
+    MT15G MT15G;
+    MT37L MT37L;
+    MT33B MT33B;
+    MT36 MT36?;
+    MT33E MT33E?;
+|};
+
+# Defines the structure of the Additional Information in the MT330 message.
+#
+# + MT15H - New Sequence  
+# + MT29A - Contact Information  
+# + MT24D - Dealing Method
+# + MT84A - Dealing Branch Party A  
+# + MT85A - Dealing Branch Party B
+# + MT26H - Counterparty's Reference
+# + MT34C - Commission and Fees 
+# + MT72 - Sender to Receiver Information
+public type MT330AddiInfo record {|
+    MT15H MT15H;
+    MT29A MT29A?;
+    MT24D MT24D?;
+    MT84A MT84A?;
+    MT85A MT85A?;
+    MT26H MT26H?;
+    MT34C MT34C?;
+    MT72 MT72?;
+|};

--- a/swiftmt/340_forward_rate_agreement_confirmation.bal
+++ b/swiftmt/340_forward_rate_agreement_confirmation.bal
@@ -1,0 +1,280 @@
+// Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# Defines the structure of an MT340 message.
+#
+# + block1 - Basic Header Block 
+# + block2 - Application Header Block
+# + block3 - User Header Block 
+# + block4 - Text Block containing Forward Rate Agreement Confirmation details
+# + block5 - Trailer Block 
+# + UnparsedTexts - Any additional unparsed texts
+public type MT340Message record {|
+    Block1 block1?;
+    Block2 block2;
+    Block3 block3?;
+    MT340Block4 block4;
+    Block5 block5?;
+    UnparsedTexts UnparsedTexts?;
+|};
+
+# Defines the elements of the MT340 message block 4.
+#
+# + MT15A - New Sequence  
+# + MT20 - Sender's Reference  
+# + MT21 - Related Reference 
+# + MT22A - Type of Operation  
+# + MT94A - Scope of Operation  
+# + MT22C - Common Reference 
+# + MT23D - Type of FRA
+# + MT21N - Contract Number Party A  
+# + MT21B - Contract Number Party B
+# + MT82A - Party A
+# + MT87A - Party B  
+# + MT77H - Type, Date, Version of Agreement
+# + MT14C - Year of Definitions
+# + Transaction - Transaction details  
+# + SettlInstAmntPayPartyB - Settlement Instructions for Settlement Amount Payable by Party B
+# + SettlInstAmntPayPartyA - Settlement Instructions for Settlement Amount Payable by Party A
+# + AddiInfo - Additional Information  
+# + AddiAmnt - Additional Amounts  
+# + RepInfo - Reporting Information
+public type MT340Block4 record {|
+    MT15A MT15A;
+    MT20 MT20;
+    MT21 MT21?;
+    MT22A MT22A;
+    MT94A MT94A?;
+    MT22C MT22C;
+    MT23D MT23D;
+    MT21N MT21N?;
+    MT21B MT21B?;
+    MT82A MT82A;
+    MT87A MT87A;
+    MT77H MT77H;
+    MT14C MT14C?;
+    MT340Transaction Transaction;
+    MT340SettlInstAmntPayPartyB SettlInstAmntPayPartyB;
+    MT340SettlInstAmntPayPartyA SettlInstAmntPayPartyA;
+    MT340AddiInfo AddiInfo?;
+    MT340AddiAmnt AddiAmnt?;
+    MT340RepInfo RepInfo?;
+|};
+
+# Defines the structure of the Transaction Information in the MT340 message.
+#
+# + MT15B - New Sequence 
+# + MT30T - Trade Date 
+# + MT32B - Currency, Notional Amount 
+# + MT30F - Effective Date  
+# + MT30P - Termination Date  
+# + MT37M - Fixed Rate 
+# + MT14F - Floating Rate Option
+# + AfbFrabbaDetails - AFB and FRABBA Details
+# + OtherDetails - Other Details
+# + MT39M - Payment Clearing Centre
+public type MT340Transaction record {|
+    MT15B MT15B;
+    MT30T MT30T;
+    MT32B MT32B;
+    MT30F MT30F;
+    MT30P MT30P;
+    MT37M MT37M;
+    MT14F MT14F;
+    MT340AfbFrabbaDetails AfbFrabbaDetails?;
+    MT340OtherDetails OtherDetails;
+    MT39M MT39M?;
+|};
+
+# Defines the structure of the AFB and FRABBA Details in the MT340Transaction.
+#
+# + MT30V - Fixing Date
+# + MT38D - Contract Period
+public type MT340AfbFrabbaDetails record {|
+    MT30V MT30V;
+    MT38D MT38D;
+|};
+
+# Defines the structure of other Details in the MT340Transaction.
+#
+# + MT38G - Designated Maturity
+# + MT14D - Floating Rate Day Count Fraction 
+# + MT17F - FRA Discounting
+# + MT18A - Number of Repetitions
+# + MT22B - Financial Centre
+public type MT340OtherDetails record {|
+    MT38G MT38G;
+    MT14D MT14D;
+    MT17F MT17F;
+    MT18A MT18A;
+    MT22B MT22B;
+|};
+
+# Defines the structure of the Settlement Instructions for Amounts Payable by Party B in the MT340 message.
+#
+# + MT15C - New Sequence  
+# + MT53A - Delivery Agent  
+# + MT86A - Intermediary 2  
+# + MT56A - Intermediary  
+# + MT57A - Receiving Agent  
+# + MT58A - Beneficiary Institution
+public type MT340SettlInstAmntPayPartyB record {|
+    MT15C MT15C;
+    MT53A MT53A?;
+    MT86A MT86A?;
+    MT56A MT56A?;
+    MT57A MT57A;
+    MT58A MT58A?;
+|};
+
+# Defines the structure of the Settlement Instructions for Amounts Payable by Party A in the MT340 message.
+#
+# + MT15D - New Sequence  
+# + MT53A - Delivery Agent  
+# + MT86A - Intermediary 2  
+# + MT56A - Intermediary  
+# + MT57A - Receiving Agent  
+# + MT58A - Beneficiary Institution
+public type MT340SettlInstAmntPayPartyA record {|
+    MT15D MT15D;
+    MT53A MT53A?;
+    MT86A MT86A?;
+    MT56A MT56A?;
+    MT57A MT57A;
+    MT58A MT58A?;
+|};
+
+# Defines the structure of the Additional Information in the MT340 message.
+#
+# + MT15E - New Sequence  
+# + MT29A - Contract Information  
+# + MT24D - Dealing Method
+# + MT88A - Broker Identification  
+# + MT71F - Broker's Commission
+# + MT21G - Broker's Reference
+# + MT72 - Sender to Receiver Information
+public type MT340AddiInfo record {|
+    MT15E MT15E;
+    MT29A MT29A?;
+    MT24D MT24D?;
+    MT88A MT88A?;
+    MT71F MT71F?;
+    MT21G MT21G?;
+    MT72 MT72?;
+|};
+
+# Defines the structure of the Additional Amounts in the MT340 message.
+#
+# + MT15F - New Sequence  
+# + MT18A - Number of Repetitions  
+# + MT30F - Payment Date
+# + MT32H - Currency, Payment Amount  
+# + MT53A - Delivery Agent
+# + MT86A - Intermediary 2  
+# + MT56A - Intermediary  
+# + MT57A - Receiving Agent
+public type MT340AddiAmnt record {|
+    MT15F MT15F;
+    MT18A MT18A;
+    MT30F MT30F;
+    MT32H MT32H;
+    MT53A MT53A?;
+    MT86A MT86A?;
+    MT56A MT56A?;
+    MT57A MT57A;
+|};
+
+# Defines the structure of the Reporting Information in the MT340 message.
+#
+# + MT15G - New Sequence  
+# + RepParties - Reporting Parties
+# + MT96A - Clearing Exception Party  
+# + MT22S - Clearing Broker Identification  
+# + MT22T - Cleared Product Identification  
+# + MT17E - Clearing Threshold Indicator 
+# + MT22U - Unique Product Identifier  
+# + MT35B - Identification of Financial Instrument  
+# + MT17H - Allocation Indicator
+# + MT17P - Collateralisation Indicator
+# + MT22V - Execution Venue
+# + MT98D - Execution Timestamp  
+# + MT17W - Non Standard Flag
+# + MT17Y - Financial Nature of the Counterparty Indicator  
+# + MT17Z - Collateral Portfolio Indicator
+# + MT22Q - Collateral Portfolio Code
+# + MT17L - Portfolio Compression Indicator
+# + MT17M - Corporate Sector Indicator
+# + MT17Q - Trade with Non-EEA Counterparty Indicator
+# + MT17S - Intragroup Trade Indicator
+# + MT17X - Commercial or Treasury Financing Indicator
+# + MT34C - Commission and Fees
+# + MT77A - Additional Reporting Information
+public type MT340RepInfo record {|
+    MT15G MT15G;
+    MT340RepParties[] RepParties?;
+    MT96A MT96A?;
+    MT22S MT22S?;
+    MT22T MT22T?;
+    MT17E MT17E?;
+    MT22U MT22U?;
+    MT35B MT35B?;
+    MT17H MT17H?;
+    MT17P MT17P?;
+    MT22V MT22V?;
+    MT98D MT98D?;
+    MT17W MT17W?;
+    MT17Y MT17Y?;
+    MT17Z MT17Z?;
+    MT22Q MT22Q?;
+    MT17L MT17L?;
+    MT17M MT17M?;
+    MT17Q MT17Q?;
+    MT17S MT17S?;
+    MT17X MT17X?;
+    MT34C MT34C?;
+    MT77A MT77A?;
+|};
+
+# Defines the structure of the Reporting Parties in the MT340RepInfo element.
+#
+# + MT22L - Reporting Jurisdiction  
+# + MT91A - Reporting Party
+# + UniqueTransactionIdentifier - Unique Transaction Identifier
+public type MT340RepParties record {|
+    MT22L MT22L;
+    MT91A MT91A?;
+    MT340UniqueTransactionIdentifier[] UniqueTransactionIdentifier?;
+|};
+
+# Defines the structure of the Unique Transaction Identifier in the MT340RepParties element.
+#
+# + MT22M - UTI Namespace/Issuer Code
+# + MT22N - Transaction Identifier
+# + PriorUniqueTransactionIdentifier - An array of prior unique transaction identifiers
+public type MT340UniqueTransactionIdentifier record {|
+    MT22M MT22M;
+    MT22N MT22N;
+    MT340PriorUniqueTransactionIdentifier[] PriorUniqueTransactionIdentifier?;
+|};
+
+# Defines the structure of the prior unique transaction identifier in the MT340UniqueTransactionIdentifier element.
+#
+# + MT22P - PUTI Namespace/Issuer Code 
+# + MT22R - Prior Transaction Identifier
+public type MT340PriorUniqueTransactionIdentifier record {|
+    MT22P MT22P;
+    MT22R MT22R;
+|};

--- a/swiftmt/341_forward_rate_agreement_settlement_confirmation.bal
+++ b/swiftmt/341_forward_rate_agreement_settlement_confirmation.bal
@@ -1,0 +1,203 @@
+// Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# Defines the structure of an MT341 message.
+#
+# + block1 - Basic Header Block 
+# + block2 - Application Header Block
+# + block3 - User Header Block 
+# + block4 - Text Block containing Forward Rate Agreement Settlement Confirmation details
+# + block5 - Trailer Block 
+# + UnparsedTexts - Any additional unparsed texts
+public type MT341Message record {|
+    Block1 block1?;
+    Block2 block2;
+    Block3 block3?;
+    MT341Block4 block4;
+    Block5 block5?;
+    UnparsedTexts UnparsedTexts?;
+|};
+
+# Defines the elements of the MT341 message block 4.
+#
+# + MT15A - New Sequence  
+# + MT20 - Sender's Reference  
+# + MT21 - Related Reference  
+# + MT22A - Type of Operation  
+# + MT94A - Scope of Operation  
+# + MT22C - Common Reference  
+# + MT23D - Type of FRA 
+# + MT21N - Contract Number Party A  
+# + MT21B - Contract Number Party B  
+# + MT82A - Party A  
+# + MT87A - Party B  
+# + MT29A - Contact Information  
+# + MT72 - Sender to Receiver Information  
+# + Transaction - Transaction Details 
+# + SettlInstAmnt - Settlement Instructions for the Settlement Amount
+# + RepInfo - Reporting Information
+public type MT341Block4 record {|
+    MT15A MT15A;
+    MT20 MT20;
+    MT21 MT21?;
+    MT22A MT22A;
+    MT94A MT94A?;
+    MT22C MT22C;
+    MT23D MT23D;
+    MT21N MT21N?;
+    MT21B MT21B?;
+    MT82A MT82A;
+    MT87A MT87A;
+    MT29A MT29A?;
+    MT72 MT72?;
+    MT341Transaction Transaction;
+    MT341SettlInstAmnt SettlInstAmnt;
+    MT341RepInfo RepInfo?;
+|};
+
+# Defines the structure of the Transaction Information in the MT341 message.
+#
+# + MT15B - New Sequence 
+# + MT30T - Trade Date
+# + MT32B - Currency, Notional Amount
+# + MT30F - Effective Date  
+# + MT30P - Termination Date
+# + MT37M - Fixed Rate
+# + AfbFrabbaDetails - AFB and FRABBA Details
+# + MT39M - Payment Clearing Centre
+public type MT341Transaction record {|
+    MT15B MT15B;
+    MT30T MT30T;
+    MT32B MT32B;
+    MT30F MT30F;
+    MT30P MT30P;
+    MT37M MT37M;
+    MT341AfbFrabbaDetails AfbFrabbaDetails?;
+    MT39M MT39M?;
+|};
+
+# Defines the structure of the AFB and FRABBA Details in the MT341Transaction.
+#
+# + MT30V - Fixing Date
+# + MT38D - Contract Period
+public type MT341AfbFrabbaDetails record {|
+    MT30V MT30V?;
+    MT38D MT38D?;
+|};
+
+# Defines the structure of the Settlement Instructions for the Settlement Amount in the MT341 message.
+#
+# + MT15C - New Sequence
+# + MT37R - Settlement Rate
+# + MT34E - Settlement Currency and Amount
+# + MT53A - Delivery Agent 
+# + MT86A - Intermediary 2
+# + MT56A - Intermediary
+# + MT57A - Receiving Agent
+# + MT58A - Beneficiary Institution
+public type MT341SettlInstAmnt record {|
+    MT15C MT15C;
+    MT37R MT37R;
+    MT34E MT34E;
+    MT53A MT53A?;
+    MT86A MT86A?;
+    MT56A MT56A?;
+    MT57A MT57A;
+    MT58A MT58A?;
+|};
+
+# Defines the structure of the Reporting Information in the MT341 message.
+#
+# + MT15G - New Sequence  
+# + RepParties - Reporting Parties
+# + MT96A - Clearing Exception Party  
+# + MT22S - Clearing Broker Identification  
+# + MT22T - Cleared Product Identification  
+# + MT17E - Clearing Threshold Indicator 
+# + MT22U - Unique Product Identifier  
+# + MT35B - Identification of Financial Instrument  
+# + MT17H - Allocation Indicator
+# + MT17P - Collateralisation Indicator
+# + MT22V - Execution Venue
+# + MT98D - Execution Timestamp  
+# + MT17W - Non Standard Flag
+# + MT17Y - Financial Nature of the Counterparty Indicator  
+# + MT17Z - Collateral Portfolio Indicator
+# + MT22Q - Collateral Portfolio Code
+# + MT17L - Portfolio Compression Indicator
+# + MT17M - Corporate Sector Indicator
+# + MT17Q - Trade with Non-EEA Counterparty Indicator
+# + MT17S - Intragroup Trade Indicator
+# + MT17X - Commercial or Treasury Financing Indicator
+# + MT34C - Commission and Fees
+# + MT77A - Additional Reporting Information
+public type MT341RepInfo record {|
+    MT15G MT15G;
+    MT341RepParties[] RepParties?;
+    MT96A MT96A?;
+    MT22S MT22S?;
+    MT22T MT22T?;
+    MT17E MT17E?;
+    MT22U MT22U?;
+    MT35B MT35B?;
+    MT17H MT17H?;
+    MT17P MT17P?;
+    MT22V MT22V?;
+    MT98D MT98D?;
+    MT17W MT17W?;
+    MT17Y MT17Y?;
+    MT17Z MT17Z?;
+    MT22Q MT22Q?;
+    MT17L MT17L?;
+    MT17M MT17M?;
+    MT17Q MT17Q?;
+    MT17S MT17S?;
+    MT17X MT17X?;
+    MT34C MT34C?;
+    MT77A MT77A?;
+|};
+
+# Defines the structure of the Reporting Parties in the MT341RepInfo element.
+#
+# + MT22L - Reporting Jurisdiction  
+# + MT91A - Reporting Party
+# + UniqueTransactionIdentifier - Unique Transaction Identifier
+public type MT341RepParties record {|
+    MT22L MT22L;
+    MT91A MT91A?;
+    MT341UniqueTransactionIdentifier[] UniqueTransactionIdentifier?;
+|};
+
+# Defines the structure of the Unique Transaction Identifier in the MT341RepParties element.
+#
+# + MT22M - UTI Namespace/Issuer Code
+# + MT22N - Transaction Identifier
+# + PriorUniqueTransactionIdentifier - An array of prior unique transaction identifiers
+public type MT341UniqueTransactionIdentifier record {|
+    MT22M MT22M;
+    MT22N MT22N;
+    MT341PriorUniqueTransactionIdentifier[] PriorUniqueTransactionIdentifier?;
+|};
+
+# Defines the structure of the prior unique transaction identifier in the MT341UniqueTransactionIdentifier element.
+#
+# + MT22P - PUTI Namespace/Issuer Code 
+# + MT22R - Prior Transaction Identifier
+public type MT341PriorUniqueTransactionIdentifier record {|
+    MT22P MT22P;
+    MT22R MT22R;
+|};
+

--- a/swiftmt/common_records.bal
+++ b/swiftmt/common_records.bal
@@ -1750,3 +1750,2371 @@ public type MessageCopy record {|
     MT90C MT90C?;
     MT90D MT90D?;
 |};
+
+# Defines the MT15A field in block 4.
+#
+# + name - The name of the field  
+# + EmpField - Empty field
+public type MT15A record {|
+    string name?;
+    EmpField EmpField;
+|};
+
+# Defines the MT22A field in block 4.
+#
+# + name - The name of the field  
+# + OpType - The operation type
+public type MT22A record {|
+    string name?;
+    OpType OpType;
+|};
+
+# Defines the type of operation.
+#
+# + content - The content of type  
+# + number - The attribute number
+public type OpType record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT94A field in block 4.
+#
+# + name - The name of the field  
+# + scope - scope
+public type MT94A record {|
+    string name?;
+    Scope scope;
+|};
+
+# Defines the scope.
+#
+# + content - The content of scope  
+# + number - The attribute number
+public type Scope record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT22C field in block 4.
+#
+# + name - The name of the field  
+# + PtyPrefix1 - Party Prefix 1  
+# + PtyPrefix2 - Party Prefix 2    
+# + PtySuffix1 - Party Suffix 1    
+# + PtySuffix2 - Party Suffix 2    
+# + RefCd - Reference Code
+public type MT22C record {|
+    string name?;
+    PtyPrefix1 PtyPrefix1;
+    PtyPrefix2 PtyPrefix2;
+    PtySuffix1 PtySuffix1;
+    PtySuffix2 PtySuffix2;
+    RefCd RefCd;
+|};
+
+# Defines the Reference Code.
+#
+# + content - The content of reference code  
+# + number - The attribute number
+public type RefCd record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the Party Prefix 1.
+#
+# + content - The content of party prefix 1  
+# + number - The attribute number
+public type PtyPrefix1 record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the Party Prefix 2.
+#
+# + content - The content of party prefix 2  
+# + number - The attribute number
+public type PtyPrefix2 record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the Party Suffix 1
+#
+# + content - The content of party suffix 1  
+# + number - The attribute number
+public type PtySuffix1 record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the Party Suffix 2
+#
+# + content - The content of party suffix 2  
+# + number - The attribute number
+public type PtySuffix2 record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT17T field in block 4.
+#
+# + name - The name of the field  
+# + Indctr - Indicator
+public type MT17T record {|
+    string name?;
+    Indctr Indctr;
+|};
+
+# Defines the MT17U field in block 4.
+#
+# + name - The name of the field  
+# + Indctr - Indicator
+public type MT17U record {|
+    string name?;
+    Indctr Indctr;
+|};
+
+# Defines the MT17I field in block 4.
+#
+# + name - The name of the field  
+# + Indctr - Indicator
+public type MT17I record {|
+    string name?;
+    Indctr Indctr;
+|};
+
+# Defines the MT82A field in block 4.
+#
+# + name - The name of the field  
+# + PrtyIdnTyp - The party identification type  
+# + PrtyIdn - The party identification  
+# + IdnCd - The identification code
+public type MT82A record {|
+    string name?;
+    PrtyIdnTyp PrtyIdnTyp?;
+    PrtyIdn PrtyIdn?;
+    IdnCd IdnCd;
+|};
+
+# Defines the MT87A field in block 4.
+#
+# + name - The name of the field  
+# + PrtyIdnTyp - The party identification type  
+# + PrtyIdn - The party identification  
+# + IdnCd - The identification code
+public type MT87A record {|
+    string name?;
+    PrtyIdnTyp PrtyIdnTyp?;
+    PrtyIdn PrtyIdn?;
+    IdnCd IdnCd;
+|};
+
+# Defines the MT83A field in block 4.
+#
+# + name - The name of the field  
+# + PrtyIdnTyp - The party identification type  
+# + PrtyIdn - The party identification  
+# + IdnCd - The identification code
+public type MT83A record {|
+    string name?;
+    PrtyIdnTyp PrtyIdnTyp?;
+    PrtyIdn PrtyIdn?;
+    IdnCd IdnCd;
+|};
+
+# Defines the MT77H field in block 4.
+#
+# + name - The name of the field   
+# + Typ - type of Agreement  
+# + Dt - date
+# + Ver - version
+public type MT77H record {|
+    string name?;
+    Typ Typ;
+    Dt Dt?;
+    Ver Ver?;
+|};
+
+# Defines the Version
+#
+# + content - The content of version  
+# + number - The attribute number
+public type Ver record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Description.Defines the MT77D field in block 4.
+#
+# + name - The name of the field   
+# + Nrtv - narrative
+public type MT77D record {|
+    string name?;
+    Nrtv Nrtv;
+|};
+
+# Defines the MT14C field in block 4.
+#
+# + name - The name of the field   
+# + Year - Year
+public type MT14C record {|
+    string name?;
+    Year Year;
+|};
+
+# Defines the Year
+#
+# + content - The content of year  
+# + number - The attribute number
+public type Year record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT17F field in block 4.
+#
+# + name - The name of the field   
+# + Indctr - Indicator
+public type MT17F record {|
+    string name?;
+    Indctr Indctr;
+|};
+
+# Defines the MT17O field in block 4.
+#
+# + name - The name of the field   
+# + Indctr - Indicator
+public type MT17O record {|
+    string name?;
+    Indctr Indctr;
+|};
+
+# Defines the MT32E field in block 4.
+#
+# + name - The name of the field  
+# + Ccy - Currency
+public type MT32E record {|
+    string name?;
+    Ccy Ccy;
+|};
+
+# Defines the MT30U field in block 4.
+#
+# + name - The name of the field  
+# + Dt - Date
+public type MT30U record {|
+    string name?;
+    Dt Dt;
+|};
+
+# Defines the MT14S field in block 4.
+#
+# + name - The name of the field  
+# + RtSrc - Rate Source  
+# + TimeLoc - Time and Location
+public type MT14S record {|
+    string name?;
+    RtSrc RtSrc;
+    TimeLoc TimeLoc?;
+|};
+
+# Defines the Rate Source.
+#
+# + content - The content of rate source  
+# + number - The attribute number
+public type RtSrc record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the Time and Location.
+#
+# + content - The content of time and location  
+# + number - The attribute number
+public type TimeLoc record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT26K field in block 4.
+#
+# + name - The name of the field  
+# + calcAgent - Calculation Agent
+public type MT26K record {|
+    string name?;
+    calcAgent calcAgent;
+|};
+
+# Defines the Calculation Agent.
+#
+# + content - The content of calculation agent  
+# + number - The attribute number
+public type calcAgent record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT21A field in block 4.
+#
+# + name - The name of the field  
+# + MsgId - The message id in the field
+public type MT21A record {|
+    string name?;
+    MsgId MsgId;
+|};
+
+# Defines the MT14E field in block 4.
+#
+# + name - The name of the field  
+# + Ref - Reference
+public type MT14E record {|
+    string name?;
+    Ref Ref;
+|};
+
+# Defines the MT15B field in block 4.
+#
+# + name - The name of the field  
+# + EmpField - Empty field
+public type MT15B record {|
+    string name?;
+    EmpField EmpField;
+|};
+
+# Defines the MT30T field in block 4.
+#
+# + name - The name of the field  
+# + Dt - Date
+public type MT30T record {|
+    string name?;
+    Dt Dt;
+|};
+
+# Defines the MT30V field in block 4.
+#
+# + name - The name of the field  
+# + Dt - Date
+public type MT30V record {|
+    string name?;
+    Dt Dt;
+|};
+
+# Defines the MT39M field in block 4.
+#
+# + name - The name of the field  
+# + CntyCd - Country Code
+public type MT39M record {|
+    string name?;
+    CntyCd CntyCd;
+|};
+
+# Defines the Country Code.
+#
+# + content - The content of country code
+# + number - The attribute number
+public type CntyCd record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT35C field in block 4.
+#
+# + name - The name of the field  
+# + DigiTknId - Digital Token Identifier
+# + Desc - Description
+public type MT35C record {|
+    string name?;
+    DigiTknId DigiTknId;
+    Desc Desc?;
+|};
+
+# Defines the Digital Token Identifier.
+#
+# + content - The content of digital token identifier
+# + number - The attribute number
+public type DigiTknId record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the description.
+#
+# + content - The content of description
+# + number - The attribute number
+public type Desc record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT15C field in block 4.
+#
+# + name - The name of the field  
+# + EmpField - Empty field
+public type MT15C record {|
+    string name?;
+    EmpField EmpField;
+|};
+
+# Defines the Empty field.
+#
+# + content - The content of empty field
+# + number - The attribute number
+public type EmpField record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT29A field in block 4.
+#
+# + name - The name of the field  
+# + Nrtv - Narrative
+public type MT29A record {|
+    string name?;
+    Nrtv Nrtv;
+|};
+
+# Defines the MT24D field in block 4.
+#
+# + name - The name of the field  
+# + method - The method
+# + AddInfo - Additional Information
+public type MT24D record {|
+    string name?;
+    Method method;
+    AddInfo AddInfo?;
+|};
+
+# Defines the method.
+#
+# + content - The content of method
+# + number - The attribute number
+public type Method record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT84A field in block 4.
+#
+# + name - The name of the field  
+# + PrtyIdnTyp - The party identification type  
+# + PrtyIdn - The party identification  
+# + IdnCd - The identification code
+public type MT84A record {|
+    string name?;
+    PrtyIdnTyp PrtyIdnTyp?;
+    PrtyIdn PrtyIdn?;
+    IdnCd IdnCd;
+|};
+
+# Defines the MT85A field in block 4.
+#
+# + name - The name of the field  
+# + PrtyIdnTyp - The party identification type  
+# + PrtyIdn - The party identification  
+# + IdnCd - The identification code
+public type MT85A record {|
+    string name?;
+    PrtyIdnTyp PrtyIdnTyp?;
+    PrtyIdn PrtyIdn?;
+    IdnCd IdnCd;
+|};
+
+# Defines the MT88A field in block 4.
+#
+# + name - The name of the field  
+# + PrtyIdnTyp - The party identification type  
+# + PrtyIdn - The party identification  
+# + IdnCd - The identification code
+public type MT88A record {|
+    string name?;
+    PrtyIdnTyp PrtyIdnTyp?;
+    PrtyIdn PrtyIdn?;
+    IdnCd IdnCd;
+|};
+
+# Defines the MT26H field in block 4.
+#
+# + name - The name of the field  
+# + MsgId - The message id in the field
+public type MT26H record {|
+    string name?;
+    MsgId MsgId;
+|};
+
+# Defines the MT21G field in block 4.
+#
+# + name - The name of the field  
+# + MsgId - The message id in the field
+public type MT21G record {|
+    string name?;
+    MsgId MsgId;
+|};
+
+# Defines the MT15D field in block 4.
+#
+# + name - The name of the field  
+# + EmpField - Empty field
+public type MT15D record {|
+    string name?;
+    EmpField EmpField;
+|};
+
+# Defines the MT17A field in block 4.
+#
+# + name - The name of the field  
+# + Indctr - Indicator
+public type MT17A record {|
+    string name?;
+    Indctr Indctr;
+|};
+
+# Defines the MT16A field in block 4.
+#
+# + name - The name of the field  
+# + nmb - Number
+public type MT16A record {|
+    string name?;
+    nmb nmb;
+|};
+
+# Defines the Number.
+#
+# + content - The content of number
+# + number - The attribute number
+public type nmb record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT15E field in block 4.
+#
+# + name - The name of the field
+# + EmpField - Empty field
+public type MT15E record {|
+    string name?;
+    EmpField EmpField;
+|};
+
+# Defines the MT81A field in block 4.
+#
+# + name - The name of the field  
+# + PrtyIdnTyp - The party identification type  
+# + PrtyIdn - The party identification  
+# + IdnCd - The identification code
+public type MT81A record {|
+    string name?;
+    PrtyIdnTyp PrtyIdnTyp?;
+    PrtyIdn PrtyIdn?;
+    IdnCd IdnCd;
+|};
+
+# Defines the MT89A field in block 4.
+#
+# + name - The name of the field  
+# + PrtyIdnTyp - The party identification type  
+# + PrtyIdn - The party identification  
+# + IdnCd - The identification code
+public type MT89A record {|
+    string name?;
+    PrtyIdnTyp PrtyIdnTyp?;
+    PrtyIdn PrtyIdn?;
+    IdnCd IdnCd;
+|};
+
+# Defines the MT96A field in block 4.
+#
+# + name - The name of the field  
+# + PrtyIdnTyp - The party identification type  
+# + PrtyIdn - The party identification  
+# + IdnCd - The identification code
+public type MT96A record {|
+    string name?;
+    PrtyIdnTyp PrtyIdnTyp?;
+    PrtyIdn PrtyIdn?;
+    IdnCd IdnCd;
+|};
+
+# Defines the MT22S field in block 4.
+#
+# + name - The name of the field  
+# + SideId - Side Indicator  
+# + Idfier - Identification
+public type MT22S record {|
+    string name?;
+    SideId SideId;
+    Idfier Idfier?;
+|};
+
+# Defines the Side Indicator.
+#
+# + content - The content of side indicator
+# + number - The attribute number
+public type SideId record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT22T field in block 4.
+#
+# + name - The name of the field
+# + Idfier - Identification
+public type MT22T record {|
+    string name?;
+    Idfier Idfier;
+|};
+
+# Defines the MT17E field in block 4.
+#
+# + name - The name of the field
+# + Indctr - Indicator
+public type MT17E record {|
+    string name?;
+    Indctr Indctr;
+|};
+
+# Defines the MT22U field in block 4.
+#
+# + name - The name of the field
+# + ProdId - Product Identifier
+public type MT22U record {|
+    string name?;
+    ProdId ProdId;
+|};
+
+# Defines the Product Identifier.
+#
+# + content - The content of product identifier
+# + number - The attribute number
+public type ProdId record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Define the MT35B field in block 4.
+#
+# + name - The name of the field  
+# + InstrId - Identification of Instrument  
+# + InstrDesc - Description of Instrument
+public type MT35B record {|
+    string name?;
+    InstrId InstrId?;
+    InstrDesc InstrDesc?;
+|};
+
+# Defines the Identification of Instrument.
+#
+# + content - The content of instrument identifier
+# + number - The attribute number
+public type InstrId record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the Description of Instrument.
+#
+# + content - The content of instrument description
+# + number - The attribute number
+public type InstrDesc record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT17H field in block 4.
+#
+# + name - The name of the field
+# + Indctr - Indicator
+public type MT17H record {|
+    string name?;
+    Indctr Indctr;
+|};
+
+# Defines the MT17P field in block 4.
+#
+# + name - The name of the field
+# + Indctr - Indicator
+public type MT17P record {|
+    string name?;
+    Indctr Indctr;
+|};
+
+# Defines the MT22V field in block 4.
+#
+# + name - The name of the field
+# + Venue - Venue
+public type MT22V record {|
+    string name?;
+    Venue Venue;
+|};
+
+# Defines the Venue.
+#
+# + content - The content of venue
+# + number - The attribute number
+public type Venue record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT98D field in block 4.
+#
+# + name - The name of the field  
+# + Dt - Date  
+# + Tm - Time  
+# + Decimals - Decimals  
+# + UtcInd - UTC Indicator
+public type MT98D record {|
+    string name?;
+    Dt Dt;
+    Tm Tm;
+    Decimals Decimals?;
+    UtcInd UtcInd?;
+|};
+
+# Defines the Decimals.
+#
+# + content - The content of decimals
+# + number - The attribute number
+public type Decimals record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the UTC Indicator.
+#
+# + content - The content of utc indicator
+# + number - The attribute number
+public type UtcInd record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT17W field in block 4.
+#
+# + name - The name of the field  
+# + Flag - Flag
+public type MT17W record {|
+    string name?;
+    Flag Flag;
+|};
+
+# Defines the Flag.
+#
+# + content - The content of flag
+# + number - The attribute number
+public type Flag record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT22W field in block 4.
+#
+# + name - The name of the field  
+# + Idfier - Identification
+public type MT22W record {|
+    string name?;
+    Idfier Idfier;
+|};
+
+# Defines the MT17Y field in block 4.
+#
+# + name - The name of the field  
+# + Indctr - Indicator
+public type MT17Y record {|
+    string name?;
+    Indctr Indctr;
+|};
+
+# Defines the MT17Z field in block 4.
+#
+# + name - The name of the field  
+# + Indctr - Indicator
+public type MT17Z record {|
+    string name?;
+    Indctr Indctr;
+|};
+
+# Defines the MT22Q field in block 4.
+#
+# + name - The name of the field  
+# + Portfolio - Portfolio
+public type MT22Q record {|
+    string name?;
+    Portfolio Portfolio;
+|};
+
+# Defines the Portfolio.
+#
+# + content - The content of portfolio
+# + number - The attribute number
+public type Portfolio record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT17L field in block 4.
+#
+# + name - The name of the field  
+# + Indctr - Indicator
+public type MT17L record {|
+    string name?;
+    Indctr Indctr;
+|};
+
+# Defines the MT17M field in block 4.
+#
+# + name - The name of the field
+# + Indctr - Indicator
+public type MT17M record {|
+    string name?;
+    Indctr Indctr;
+|};
+
+# Defines the MT17Q field in block 4.
+#
+# + name - The name of the field
+# + Indctr - Indicator
+public type MT17Q record {|
+    string name?;
+    Indctr Indctr;
+|};
+
+# Defines the MT17S field in block 4.
+#
+# + name - The name of the field
+# + Indctr - Indicator
+public type MT17S record {|
+    string name?;
+    Indctr Indctr;
+|};
+
+# Defines the MT17X field in block 4.
+#
+# + name - The name of the field
+# + Indctr - Indicator
+public type MT17X record {|
+    string name?;
+    Indctr Indctr;
+|};
+
+# Defines the MT98G field in block 4.
+#
+# + name - The name of the field  
+# + Dt - Date  
+# + Tm - Tm  
+# + Decimals - Decimals  
+# + UtcInd - UTC Indicator
+public type MT98G record {|
+    string name?;
+    Dt Dt;
+    Tm Tm;
+    Decimals Decimals?;
+    UtcInd UtcInd?;
+|};
+
+# Defines the MT98H field in block 4.
+#
+# + name - The name of the field  
+# + Tm - Tm  
+# + Decimals - Decimals  
+# + UtcInd - UTC Indicator
+public type MT98H record {|
+    string name?;
+    Tm Tm;
+    Decimals Decimals?;
+    UtcInd UtcInd?;
+|};
+
+# Defines the MT34C field in block 4.
+#
+# + name - The name of the field  
+# + CommType - Commission Type  
+# + Sign - Sign 
+# + Ccy - Currency/Percent  
+# + Amnt - Amount/Rate
+public type MT34C record {|
+    string name?;
+    CommType CommType;
+    Sign Sign?;
+    Ccy Ccy;
+    Amnt Amnt;
+|};
+
+# Defines the Commission Type.
+#
+# + content - The content of commission type
+# + number - The attribute number
+public type CommType record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the Sign of Currency.
+#
+# + content - The content of sign
+# + number - The attribute number
+public type Sign record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines MT22L field in block 4.
+#
+# + name - The name of the field  
+# + RptJuris - Reporting Jurisdiction
+public type MT22L record {|
+    string name?;
+    RptJuris RptJuris;
+|};
+
+# Defines the Reporting Jurisdiction.
+#
+# + content - The content of reporting jurisdiction
+# + number - The attribute number
+public type RptJuris record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT91A field in block 4.
+#
+# + name - The name of the field  
+# + PrtyIdnTyp - The party identification type  
+# + PrtyIdn - The party identification  
+# + IdnCd - The identification code
+public type MT91A record {|
+    string name?;
+    PrtyIdnTyp PrtyIdnTyp?;
+    PrtyIdn PrtyIdn?;
+    IdnCd IdnCd;
+|};
+
+# Defines the MT22M field in block 4.
+#
+# + name - The name of the field  
+# + Nmspace - Namespace
+public type MT22M record {|
+    string name?;
+    Nmspace Nmspace;
+|};
+
+# Defines the Namespace.
+#
+# + content - The content of namespace
+# + number - The attribute number
+public type Nmspace record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT22N field in block 4.
+#
+# + name - The name of the field  
+# + Idfier - Identifier
+public type MT22N record {|
+    string name?;
+    Idfier Idfier;
+|};
+
+# Defines the Identifier for transaction.
+#
+# + content - The content of identifier
+# + number - The attribute number
+public type Idfier record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT22P field in block 4.
+#
+# + name - The name of the field  
+# + Nmspace - Namespace
+public type MT22P record {|
+    string name?;
+    Nmspace Nmspace;
+|};
+
+# Defines the MT22R field in block 4.
+#
+# + name - The name of the field  
+# + Idfier - Identifier
+public type MT22R record {|
+    string name?;
+    Idfier Idfier;
+|};
+
+# Defines the MT15F field in block 4.
+#
+# + name - The name of the field
+# + EmpField - Empty field
+public type MT15F record {|
+    string name?;
+    EmpField EmpField;
+|};
+
+# Defines the MT21H field in block 4.
+#
+# + name - The name of the field  
+# + EveType - Event Type  
+# + RefPrevConf - Reference to Previous Confirmation
+public type MT21H record {|
+    string name?;
+    EveType EveType;
+    RefPrevConf RefPrevConf;
+|};
+
+# Defines the Event Type.
+#
+# + content - The content of event type
+# + number - The attribute number
+public type EveType record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the Reference to Previous Confirmation.
+#
+# + content - The content of reference to previous confirmation
+# + number - The attribute number
+public type RefPrevConf record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT30F field in block 4.
+#
+# + name - The name of the field  
+# + Dt - Date
+public type MT30F record {|
+    string name?;
+    Dt Dt;
+|};
+
+# Defines the MT32H field in block 4.
+#
+# + name - The name of the field  
+# + Sign - Sign 
+# + Ccy - Currency  
+# + Amnt - Amount
+public type MT32H record {|
+    string name?;
+    Sign Sign?;
+    Ccy Ccy;
+    Amnt Amnt;
+|};
+
+# Defines the MT33E field in block 4.
+#
+# + name - The name of the field  
+# + Ccy - Currency  
+# + Amnt - Amount
+public type MT33E record {|
+    string name?;
+    Ccy Ccy;
+    Amnt Amnt;
+|};
+
+# Defines the MT17N field in block 4.
+#
+# + name - The name of the field 
+# + Indctr - Indicator
+public type MT17N record {|
+    string name?;
+    Indctr Indctr;
+|};
+
+# Defines the MT21P field in block 4.
+#
+# + name - The name of the field  
+# + MsgId - Reference
+public type MT21P record {|
+    string name?;
+    MsgId MsgId;
+|};
+
+# Defines the MT17G field in block 4.
+#
+# + name - The name of the field  
+# + Indctr - Indicator
+public type MT17G record {|
+    string name?;
+    Indctr Indctr;
+|};
+
+# Defines the MT32G field in block 4.
+#
+# + name - The name of the field  
+# + Ccy - Currency 
+# + Amnt - Amount
+public type MT32G record {|
+    string name?;
+    Ccy Ccy;
+    Amnt Amnt;
+|};
+
+# Defines the MT34B field in block 4.
+#
+# + name - The name of the field  
+# + Ccy - Currency
+# + Amnt - Amount
+public type MT34B record {|
+    string name?;
+    Ccy Ccy;
+    Amnt Amnt;
+|};
+
+# Defines the MT22 field in block 4.
+#
+# + name - The name of the field  
+# + Cd - The Code
+# + CmnRef - Common Reference
+public type MT22 record {|
+    string name?;
+    Cd Cd;
+    CmnRef CmnRef;
+|};
+
+# Defines the Common Reference.
+#
+# + content - The content of common reference
+# + number - The attribute number
+public type CmnRef record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT31C field in block 4.
+#
+# + name - The name of the field
+# + Dt - Date
+public type MT31C record {|
+    string name?;
+    Dt Dt;
+|};
+
+# Defines the MT31G field in block 4.
+#
+# + name - The name of the field
+# + Dt - Date
+# + Tm - Time  
+# + Lctn - Location
+public type MT31G record {|
+    string name?;
+    Dt Dt;
+    Tm Tm;
+    Lctn Lctn;
+|};
+
+# Defines the MT31E field in block 4.
+#
+# + name - The name of the field
+# + Dt - Date
+public type MT31E record {|
+    string name?;
+    Dt Dt;
+|};
+
+# Defines the MT26F field in block 4.
+#
+# + name - The name of the field
+# + Typ - The type of settlement
+public type MT26F record {|
+    string name?;
+    Typ Typ;
+|};
+
+# Defines the MT37K field in block 4.
+#
+# + name - The name of the field  
+# + Ccy - Currency
+# + Rt - Rate
+public type MT37K record {|
+    string name?;
+    Ccy Ccy;
+    Rt Rt;
+|};
+
+# Defines the MT34A field in block 4.
+#
+# + name - The name of the field  
+# + Dt - Date  
+# + Ccy - Currency  
+# + Amnt - Amount
+public type MT34A record {|
+    string name?;
+    Dt Dt;
+    Ccy Ccy;
+    Amnt Amnt;
+|};
+
+# Defines the MT21N field in block 4.
+#
+# + name - The name of the field  
+# + cntrctNum - Contract Number
+public type MT21N record {|
+    string name?;
+    cntrctNum cntrctNum;
+|};
+
+# Defines the Contract Number.
+#
+# + content - The content of contract number  
+# + number - The attribute number
+public type cntrctNum record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT21N field in block 4.
+#
+# + name - The name of the field  
+# + cntrctNum - Contract Number
+public type MT21B record {|
+    string name?;
+    CmnRef cntrctNum;
+|};
+
+# Defines the MT12F field in block 4.
+#
+# + name - The name of the field  
+# + Style - Option or Forward Style
+public type MT12F record {|
+    string name?;
+    Style Style;
+|};
+
+# Defines the Style.
+#
+# + content - The content of style  
+# + number - The attribute number
+public type Style record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT12E field in block 4.
+#
+# + name - The name of the field
+# + Style - Expiration Style
+public type MT12E record {|
+    string name?;
+    Style Style;
+|};
+
+# Defines the MT12C field in block 4.
+#
+# + name - The name of the field
+# + OpType - Option Type
+public type MT12D record {|
+    string name?;
+    OpType OpType;
+|};
+
+# Defines the MT22K field in block 4.
+#
+# + name - The name of the field  
+# + EveType - Type of Event
+# + Nrtv - Narrative
+public type MT22K record {|
+    string name?;
+    EveType EveType;
+    Nrtv Nrtv?;
+|};
+
+# Defines the MT29H field in block 4.
+#
+# + name - The name of the field  
+# + Lctn - Location
+public type MT29H record {|
+    string name?;
+    Lctn Lctn;
+|};
+
+# Defines the MT17V field in block 4.
+#
+# + name - The name of the field  
+# + Indctr - Indicator
+public type MT17V record {|
+    string name?;
+    Indctr Indctr;
+|};
+
+# Defines the MT30X field in block 4.
+#
+# + name - The name of the field  
+# + Dt - Date
+public type MT30X record {|
+    string name?;
+    Dt Dt;
+|};
+
+# Defines the MT30A field in block 4.
+#
+# + name - The name of the field  
+# + Dt - Date
+# + Indctr - Indicator  
+# + nmb - Number
+public type MT30A record {|
+    string name?;
+    Dt Dt;
+    Indctr Indctr;
+    nmb nmb;
+|};
+
+# Defines the MT86A field in block 4.
+#
+# + name - The name of the field  
+# + PrtyIdnTyp - Party Identification Type  
+# + PrtyIdn - Party Identification
+# + IdnCd - Identifier Code
+public type MT86A record {|
+    string name?;
+    PrtyIdnTyp PrtyIdnTyp?;
+    PrtyIdn PrtyIdn;
+    IdnCd IdnCd;
+|};
+
+# Defines the MT30P field in block 4.
+#
+# + name - The name of the field  
+# + Dt - Date
+public type MT30P record {|
+    string name?;
+    Dt Dt;
+|};
+
+# Defines the MT30Q field in block 4.
+#
+# + name - The name of the field  
+# + Dt - Date
+public type MT30Q record {|
+    string name?;
+    Dt Dt;
+|};
+
+# Defines the MT30H field in block 4.
+#
+# + name - The name of the field  
+# + Dt - Date
+public type MT30H record {|
+    string name?;
+    Dt Dt;
+|};
+
+# Defines the MT22G field in block 4.
+#
+# + name - The name of the field  
+# + BarrTyp - Barrier Type
+public type MT22G record {|
+    string name?;
+    BarrTyp BarrTyp;
+|};
+
+# Defines the Barrier Type.
+#
+# + content - The content of barrier type  
+# + number - The attribute number
+public type BarrTyp record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT17C field in block 4.
+#
+# + name - The name of the field  
+# + Indctr - Indicator
+public type MT17C record {|
+    string name?;
+    Indctr Indctr;
+|};
+
+# Defines the MT37J field in block 4.
+#
+# + name - The name of the field  
+# + Rt - Rate
+public type MT37J record {|
+    string name?;
+    Rt Rt;
+|};
+
+# Defines the MT37L field in block 4.
+#
+# + name - The name of the field  
+# + Rt - Rate
+public type MT37L record {|
+    string name?;
+    Rt Rt;
+|};
+
+# Defines the MT29I field in block 4.
+#
+# + name - The name of the field  
+# + BarrDeterBusinessDays - Barrier Determination Business Days
+public type MT29I record {|
+    string name?;
+    BarrDeterBusinessDays BarrDeterBusinessDays;
+|};
+
+# Defines the Barrier Determination Business Days. 
+#
+# + content - The content of barrier determination business days
+# + number - The attribute number
+public type BarrDeterBusinessDays record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT14H field in block 4.
+#
+# + name - The name of the field  
+# + Conv - Convention
+public type MT14H record {|
+    string name?;
+    Conv Conv;
+|};
+
+# Defines the Convention.
+#
+# + content - The content of convention  
+# + number - The attribute number
+public type Conv record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT14K field in block 4.
+#
+# + name - The name of the field  
+# + Conv - Convention
+public type MT14K record {|
+    string name?;
+    Conv Conv;
+|};
+
+# Defines the MT14L field in block 4.
+#
+# + name - The name of the field  
+# + Conv - Convention
+public type MT14L record {|
+    string name?;
+    Conv Conv;
+|};
+
+# Defines the MT14M field in block 4.
+#
+# + name - The name of the field  
+# + BarrTyp - Type
+public type MT14M record {|
+    string name?;
+    BarrTyp BarrTyp;
+|};
+
+# Defines the MT29O field in block 4.
+#
+# + name - The name of the field  
+# + Lctn - Location  
+# + StartTm - Start Time  
+# + EndTm - End Time
+public type MT29O record {|
+    string name?;
+    Lctn Lctn;
+    CtTm StartTm;
+    CtTm EndTm;
+|};
+
+# Defines Continuous Time.
+#
+# + content - The content of time  
+# + number - The attribute number
+public type CtTm record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT14N field in block 4.
+#
+# + name - The name of the field  
+# + Market - Market
+public type MT14N record {|
+    string name?;
+    Market Market;
+|};
+
+# Defines the Market.
+#
+# + content - The content of market  
+# + number - The attribute number
+public type Market record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT29J field in block 4.
+#
+# + name - The name of the field
+# + Lctn - Location
+# + Tm - Time
+public type MT29J record {|
+    string name?;
+    Lctn Lctn;
+    CtTm Tm;
+|};
+
+# Defines the MT14O field in block 4.
+#
+# + name - The name of the field  
+# + Typ - Type
+public type MT14O record {|
+    string name?;
+    BarrTyp Typ;
+|};
+
+# Defines the MT33Z field in block 4.
+#
+# + name - The name of the field  
+# + Amnt - Amount
+public type MT33Z record {|
+    string name?;
+    Amnt Amnt;
+|};
+
+# Defines the MT30I field in block 4.
+#
+# + name - The name of the field  
+# + Dt - Date or Start Date  
+# + EndDt - End Date
+public type MT30I record {|
+    string name?;
+    Dt Dt;
+    Dt EndDt?;
+|};
+
+# Defines the MT15G field in block 4.
+#
+# + name - The name of the field  
+# + EmpField - Empty field
+public type MT15G record {|
+    string name?;
+    EmpField EmpField;
+|};
+
+# Defines the MT32Q field in block 4.
+#
+# + name - The name of the field  
+# + Ccy1 - Currency 
+# + Ccy2 - Currency
+public type MT32Q record {|
+    string name?;
+    Ccy Ccy1;
+    Ccy Ccy2;
+|};
+
+# Defines the MT15H field in block 4.
+#
+# + name - The name of the field  
+# + EmpField - Empty field
+public type MT15H record {|
+    string name?;
+    EmpField EmpField;
+|};
+
+# Defines the MT15I field in block 4.
+#
+# + name - The name of the field  
+# + EmpField - Empty field
+public type MT15I record {|
+    string name?;
+    EmpField EmpField;
+|};
+
+# Defines the MT12G field in block 4.
+#
+# + name - The name of the field  
+# + Style - Early Termination  Style
+public type MT12G record {|
+    string name?;
+    Style Style;
+|};
+
+# Defines the MT22Y field in block 4.
+#
+# + name - The name of the field  
+# + Period - Period
+public type MT22Y record {|
+    string name?;
+    Period Period;
+|};
+
+# Defines the Period.
+#
+# + content - The content of period  
+# + number - The attribute number
+public type Period record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT30Y field in block 4.
+#
+# + name - The name of the field  
+# + Dt - Date
+public type MT30Y record {|
+    string name?;
+    Dt Dt;
+|};
+
+# Defines the MT29L field in block 4.
+#
+# + name - The name of the field  
+# + Dt - Date
+# + Lctn - Location  
+# + Tm - Time
+public type MT29L record {|
+    string name?;
+    Dt Dt;
+    Lctn Lctn;
+    CtTm Tm;
+|};
+
+# Defines the MT29E field in block 4.
+#
+# + name - The name of the field  
+# + Lctn - Location
+# + Tm - Time
+public type MT29E record {|
+    string name?;
+    Lctn Lctn;
+    CtTm Tm;
+|};
+
+# Defines the MT29M field in block 4.
+#
+# + name - The name of the field  
+# + Lctn - Location
+# + Tm - Time
+public type MT29M record {|
+    string name?;
+    Lctn Lctn;
+    CtTm Tm;
+|};
+
+# Defines the MT29N field in block 4.
+#
+# + name - The name of the field  
+# + Dt - Date
+# + Lctn - Location  
+# + Tm - Time
+public type MT29N record {|
+    string name?;
+    Dt Dt;
+    Lctn Lctn;
+    CtTm Tm;
+|};
+
+# Defines the MT30Z field in block 4.
+#
+# + name - The name of the field  
+# + Dt - Date
+public type MT30Z record {|
+    string name?;
+    Dt Dt;
+|};
+
+# Defines the MT15J field in block 4.
+#
+# + name - The name of the field  
+# + EmpField - Empty field
+public type MT15J record {|
+    string name?;
+    EmpField EmpField;
+|};
+
+# Defines the MT14P field in block 4.
+#
+# + name - The name of the field  
+# + Method - Method
+public type MT14P record {|
+    string name?;
+    Method Method;
+|};
+
+# Defines the MT29Q field in block 4.
+#
+# + name - The name of the field  
+# + ValvBusiDays - Valuation Business Days
+public type MT29Q record {|
+    string name?;
+    ValvBusiDays ValvBusiDays;
+|};
+
+# Defines the Valuation Business Days.
+#
+# + content - The content of valuation business days
+# + number - The attribute number
+public type ValvBusiDays record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT14R field in block 4.
+#
+# + name - The name of the field  
+# + Conv - Convention
+public type MT14R record {|
+    string name?;
+    Conv Conv;
+|};
+
+# Defines the MT14Q field in block 4.
+#
+# + name - The name of the field  
+# + Cons - Consequence
+public type MT14Q record {|
+    string name?;
+    Cons Cons;
+|};
+
+# Defines the Consequence.
+#
+# + content - The content of consequence  
+# + number - The attribute number
+public type Cons record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT14B field in block 4.
+#
+# + name - The name of the field  
+# + AdjTyp - Adjustment Type
+public type MT14B record {|
+    string name?;
+    AdjTyp AdjTyp;
+|};
+
+# Defines the Adjustment Type.
+#
+# + content - The content of adjustment type  
+# + number - The attribute number
+public type AdjTyp record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT19C field in block 4.
+#
+# + name - The name of the field  
+# + Sign - Sign
+# + Fac - Factor
+public type MT19C record {|
+    string name?;
+    SignM Sign;
+    Fac Fac;
+|};
+
+# Defines the Math Sign.
+#
+# + content - The content of sign  
+# + number - The attribute number
+public type SignM record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the Factor.
+#
+# + content - The content of factor  
+# + number - The attribute number
+public type Fac record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT19Y field in block 4.
+#
+# + name - The name of the field  
+# + Wght - Weight
+public type MT19Y record {|
+    string name?;
+    Wght Wght;
+|};
+
+# Defines the Weight.
+#
+# + content - The content of weight  
+# + number - The attribute number
+public type Wght record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT30K field in block 4.
+#
+# + name - The name of the field  
+# + Dt - Date or Start Date
+# + EndDt - End Date
+public type MT30K record {|
+    string name?;
+    Dt Dt;
+    Dt EndDt?;
+|};
+
+# Defines the MT19Z field in block 4.
+#
+# + name - The name of the field  
+# + Wght - Weight
+public type MT19Z record {|
+    string name?;
+    Wght Wght;
+|};
+
+# Defines the MT15K field in block 4.
+#
+# + name - The name of the field  
+# + EmpField - Empty field
+public type MT15K record {|
+    string name?;
+    EmpField EmpField;
+|};
+
+# Defines the MT15L field in block 4.
+#
+# + name - The name of the field  
+# + EmpField - Empty field
+public type MT15L record {|
+    string name?;
+    EmpField EmpField;
+|};
+
+# Defines the MT15M field in block 4.
+#
+# + name - The name of the field  
+# + EmpField - Empty field
+public type MT15M record {|
+    string name?;
+    EmpField EmpField;
+|};
+
+# Defines the MT18A field in block 4.
+#
+# + name - The name of the field  
+# + nmb - Number
+public type MT18A record {|
+    string name?;
+    nmb nmb;
+|};
+
+# Defines the MT22B field in block 4.
+#
+# + name - The name of the field  
+# + EveType - Type
+public type MT22B record {|
+    string name?;
+    EveType EveType;
+|};
+
+# Defines the MT17R field in block 4.
+#
+# + name - The name of the field
+# + Indctr - Indicator
+public type MT17R record {|
+    string name?;
+    Indctr Indctr;
+|};
+
+# Defines the MT34E field in block 4.
+#
+# + name - The name of the field  
+# + Sign - Sign
+# + Ccy - Currency  
+# + Amnt - Amount
+public type MT34E record {|
+    string name?;
+    Sign Sign?;
+    Ccy Ccy;
+    Amnt Amnt;
+|};
+
+# Defines the MT37G field in block 4.
+#
+# + name - The name of the field  
+# + Sign - Sign
+# + Rt - Rate
+public type MT37G record {|
+    string name?;
+    SignM Sign?;
+    Rt Rt;
+|};
+
+# Defines the MT14D field in block 4.
+#
+# + name - The name of the field  
+# + IsdaCd - Code
+public type MT14D record {|
+    string name?;
+    IsdaCd IsdaCd;
+|};
+
+# Defines the ISDA Code.
+#
+# + content - The content of ISDA code  
+# + number - The attribute number
+public type IsdaCd record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT38J field in block 4.
+#
+# + name - The name of the field  
+# + Indctr - Indicator  
+# + nmb - Number
+public type MT38J record {|
+    string name?;
+    Indctr Indctr;
+    nmb nmb;
+|};
+
+# Defines the MT16R field in block 4.
+#
+# + name - The name of the field  
+# + BlockSt - Start of Block
+public type MT16R record {|
+    string name?;
+    BlockSt BlockSt;
+|};
+
+# Defines start of block.
+#
+# + content - The content of block start  
+# + number - The attribute number
+public type BlockSt record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines End of block.
+#
+# + content - The content of block End  
+# + number - The attribute number
+public type BlockEnd record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT20C field in block 4.
+#
+# + name - The name of the field  
+# + Qual - Qualifier
+# + Ref - Reference
+public type MT20C record {|
+    string name?;
+    Qual Qual;
+    Ref Ref;
+|};
+
+# Defines the Qualifier.
+#
+# + content - The content of qualifier  
+# + number - The attribute number
+public type Qual record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT23G field in block 4. 
+#
+# + name - The name of the field  
+# + Fun - Function
+# + SubFun - Sub Function
+public type MT23G record {|
+    string name?;
+    Fun Fun;
+    SubFun SubFun?;
+|};
+
+# Defines the Function.
+#
+# + content - The content of function  
+# + number - The attribute number
+public type Fun record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the Sub Function.
+#
+# + content - The content of sub function  
+# + number - The attribute number
+public type SubFun record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT23H field in block 4.
+#
+# + name - The name of the field  
+# + Qual - Qualifier
+# + Indctr - Indicator
+public type MT22H record {|
+    string name?;
+    Qual Qual;
+    Indctr Indctr;
+|};
+
+# Defines the MT99B field in block 4.
+#
+# + name - The name of the field
+# + Qual - Qualifier
+# + nmb - Number
+public type MT99B record {|
+    string name?;
+    Qual Qual;
+    nmb nmb;
+|};
+
+# Defines the MT16S field in block 4.
+#
+# + name - The name of the field  
+# + BlockEnd - End of Block
+public type MT16S record {|
+    string name?;
+    BlockEnd BlockEnd;
+|};
+
+# Defines the MT13A field in block 4.
+#
+# + name - The name of the field  
+# + Qual - Qualifier
+# + NumbId - Number Id
+# + DtSrcSchm - Data Source Scheme
+public type MT13A record {|
+    string name?;
+    Qual Qual;
+    NumbId NumbId;
+    DtSrcSchm DtSrcSchm?;
+|};
+
+# Defines the Number Id.
+#
+# + content - The content of number id  
+# + number - The attribute number
+public type NumbId record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the Data Source Scheme.
+#
+# + content - The content of data source scheme 
+# + number - The attribute number
+public type DtSrcSchm record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT98A field in block 4.
+#
+# + name - The name of the field  
+# + Qual - Qualifier
+# + Dt - Date
+public type MT98A record {|
+    string name?;
+    Qual Qual;
+    Dt Dt;
+|};
+
+# Defines the MT19A field in block 4.
+#
+# + name - The name of the field  
+# + Qual - Qualifier
+# + Sign - Sign  
+# + CurrCd - Currency Code  
+# + Amnt - Amount
+public type MT19A record {|
+    string name?;
+    Qual Qual;
+    Sign Sign?;
+    CurrCd CurrCd;
+    Amnt Amnt;
+|};
+
+# Defines the Currency Code.
+#
+# + content - The content of currency code  
+# + number - The attribute number
+public type CurrCd record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT92A field in block 4.
+#
+# + name - The name of the field  
+# + Qual - Qualifier
+# + Sign - Sign  
+# + Rt - Rate
+public type MT92A record {|
+    string name?;
+    Qual Qual;
+    Sign Sign?;
+    Rt Rt;
+|};
+
+# Defines the MT94C field in block 4.
+#
+# + name - The name of the field  
+# + Qual - Qualifier
+# + CntyCd - Country Code
+public type MT94C record {|
+    string name?;
+    Qual Qual;
+    CntyCd CntyCd;
+|};
+
+# Defines the MT95C field in block 4.
+#
+# + name - The name of the field  
+# + Qual - Qualifier
+# + DtSrcSchm - Data Source Scheme  
+# + PropCd - Proprietary Code
+public type MT95A record {|
+    string name?;
+    Qual Qual;
+    DtSrcSchm DtSrcSchm;
+    PropCd PropCd;
+|};
+
+# Defines the Proprietary Code.
+#
+# + content - The content of proprietary code
+# + number - The attribute number
+public type PropCd record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT97A field in block 4.
+#
+# + name - The name of the field  
+# + Qual - Qualifier
+# + AccNmb - Account Number
+public type MT97A record {|
+    string name?;
+    Qual Qual;
+    AccNmb AccNmb;
+|};
+
+# Defines the Account Number.
+#
+# + content - The content of account number  
+# + number - The attribute number
+public type AccNmb record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT70C field in block 4.
+#
+# + name - The name of the field  
+# + Qual - Qualifier
+# + Nrtv - Narrative
+public type MT70C record {|
+    string name?;
+    Qual Qual;
+    Nrtv Nrtv;
+|};
+
+# Defines the MT38A field in block 4.
+#
+# + name - The name of the field  
+# + Period - Period
+public type MT38A record {|
+    string name?;
+    Period Period;
+|};
+
+# Defines the MT37M field in block 4.
+#
+# + name - The name of the field  
+# + Sign - Sign
+# + Rt - Rate
+public type MT37M record {|
+    string name?;
+    SignM Sign?;
+    Rt Rt;
+|};
+
+# Defines the MT14F field in block 4.
+#
+# + name - The name of the field  
+# + FlRt - Floating Rate Option
+public type MT14F record {|
+    string name?;
+    FlRtOp FlRt;
+|};
+
+# Defines the Floating rate Option.
+#
+# + content - The content of floating rate option
+# + number - The attribute number
+public type FlRtOp record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT38D field in block 4.
+#
+# + name - The name of the field  
+# + Period - Period
+public type MT38D record {|
+    string name?;
+    Period Period;
+|};
+
+# Defines the MT38E field in block 4.
+#
+# + name - The name of the field
+# + NmbFr - Number From
+# + PerFr - Period From  
+# + NmbTo - Number To  
+# + PerTo - Period To
+public type MT38G record {|
+    string name?;
+    NmbFr NmbFr;
+    PerFr PerFr;
+    NmbTo NmbTo;
+    PerTo PerTo;
+|};
+
+# Defines the 'Number From' in MT38G.
+#
+# + content - content of 'Number From'  
+# + number - attribute number
+public type NmbFr record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the 'Period From' in MT38G.
+#
+# + content - content of 'Period From'
+# + number - attribute number
+public type PerFr record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the 'Number To' in MT38G.
+#
+# + content - content of 'Number To'
+# + number - attribute number
+public type NmbTo record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the 'Period To' in MT38G.
+#
+# + content - content of 'Period To'
+# + number - attribute number
+public type PerTo record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT23D field in block 4.
+#
+# + name - The name of the field
+# + FraTyp - FRA Type
+public type MT23D record {|
+    string name?;
+    FraTyp FraTyp;
+|};
+
+# Defines the FRA Type.
+#
+# + content - content of FRA type  
+# + number - attribute number
+public type FraTyp record {|
+    string content;
+    @xmldata:Attribute
+    string number?;
+|};
+
+# Defines the MT37R field in block 4.
+#
+# + name - The name of the field  
+# + Sign - Sign
+# + Rt - Rate
+public type MT37R record {|
+    string name?;
+    SignM Sign?;
+    Rt Rt;
+|};


### PR DESCRIPTION
## Purpose
Introduce Ballerina records for SWIFT MT3xx (Volume 1) message types, enabling structured representation and easier handling of financial messages.

## Goals
Enhance the Ballerina SWIFT MT library by providing a standardized data model for MT3xx (Volume 1) messages (MT300, MT304, MT305, MT306, MT320, MT321, MT330, MT340, MT341).