### PR TITLE
Add support for block5 multiple key values

### DIFF
--- a/swiftmt/Dependencies.toml
+++ b/swiftmt/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.10.1"
+distribution-version = "2201.10.5"
 
 [[package]]
 org = "ballerina"

--- a/swiftmt/common_records.bal
+++ b/swiftmt/common_records.bal
@@ -1293,7 +1293,7 @@ public type Tag record {|
 #
 # + tag - The tag in the block
 public type Block5 record {|
-    Tag tag?;
+    Tag[] tag?;
 |};
 
 # Defines unparsed text messages.


### PR DESCRIPTION
## Purpose
> Add support for block5 multiple key values.
Swift MT block 5 can have multiple fields similar to {5:{CHK:8741A05057F5}{TNG:}} and from the provide library everything will be mapped to an array of records named Tag.
